### PR TITLE
Fix side panel toggle ui bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.7 (Jul 04, 2025)
+- Bug fix: Fixed an issue where the experimental side panel feature was not working as expected. https://github.com/haydencbarnes/jira-time-tracker-ext/issues/6
+
 ## 1.3.6 (Jul 04, 2025)
 - Feature: Added Jira Issue ID Detection as an experimental feature. The extension scans any web-page for Jira issue IDs (e.g. ABC-123, PROJECT-456). A subtle highlight is applied and a small blue ⏱ "log-time" icon is injected to the right of the ID. Clicking the icon opens the instant Log-Time popup while the ID itself remains a normal link.
 - UX: Blue "Jira detection" badge now appears bottom-right when the detector first runs. Also sped up some other animations in the extension.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Jira Log Time",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Log/Track your time in Jira in seconds!",
   "host_permissions": [
     "<all_urls>"

--- a/options.html
+++ b/options.html
@@ -350,6 +350,40 @@
             font-family: "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
         }
 
+        /* BETA badge for options - matching content-script style */
+        .jira-popup-beta-badge {
+            display: inline-block;
+            background: #FF6B35;
+            color: white;
+            font-size: 10px;
+            font-weight: 700;
+            padding: 2px 6px;
+            border-radius: 8px;
+            margin-left: 8px;
+            vertical-align: middle;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            line-height: 1;
+            box-shadow: 0 1px 3px rgba(255, 107, 53, 0.3);
+            animation: jiraBetaPulse 2s ease-in-out infinite;
+        }
+
+        body.dark-mode .jira-popup-beta-badge {
+            background: #FF8C42;
+            box-shadow: 0 1px 3px rgba(255, 140, 66, 0.4);
+        }
+
+        @keyframes jiraBetaPulse {
+            0%, 100% { 
+                opacity: 1; 
+                transform: scale(1);
+            }
+            50% { 
+                opacity: 0.8; 
+                transform: scale(1.05);
+            }
+        }
+
     </style>
 </head>
 
@@ -436,12 +470,13 @@
             </tr>
             <tr id="sidePanelRow" style="display: none;">
                 <td>Side Panel</td>
-                <td><div style="display: flex; align-items: center;">
+                <td>
                     <label class="toggle-switch">
-                      <input type="checkbox" id="sidePanelToggle">
-                      <span class="slider"></span>
+                        <input type="checkbox" id="sidePanelToggle">
+                        <span class="slider"></span>
                     </label>
-                  </div></td>
+                    <span class="jira-popup-beta-badge">Beta</span>
+                </td>
             </tr>
             <tr>
                 <td>Version</td>

--- a/options.js
+++ b/options.js
@@ -100,10 +100,7 @@
         });
     });
 
-    sidePanelToggle.addEventListener('change', function() {
-        const isEnabled = this.checked;
-        chrome.storage.sync.set({ sidePanelEnabled: isEnabled });
-    });
+
 
     // Create shapes for the experimental features slider
     const shapeCount = 15;

--- a/options.js
+++ b/options.js
@@ -16,12 +16,6 @@
     const sidePanelToggle = document.getElementById('sidePanelToggle');
     const sidePanelRow = document.getElementById('sidePanelRow');
 
-    sidePanelRow.style.display = experimentalFeaturesToggle.checked ? 'table-row' : 'none';
-    if (!experimentalFeaturesToggle.checked) {
-        sidePanelToggle.checked = false;
-        chrome.storage.sync.set({ sidePanelEnabled: false });
-    }
-
     // Add proper theme toggle functionality
     document.addEventListener('DOMContentLoaded', function() {
         const themeToggle = document.getElementById('themeToggle');
@@ -227,11 +221,7 @@
           systemThemeToggle.checked = items.followSystemTheme;
 
           sidePanelRow.style.display = items.experimentalFeatures ? 'table-row' : 'none';
-          if (items.experimentalFeatures && items.sidePanelEnabled) {
-            sidePanelToggle.checked = items.sidePanelEnabled;
-          } else {
-            sidePanelToggle.checked = false;
-          }
+          sidePanelToggle.checked = items.experimentalFeatures && items.sidePanelEnabled;
 
           jiraTypeSelect.dispatchEvent(new Event('change'));
 


### PR DESCRIPTION
Fix side panel setting toggle UI to correctly reflect its enabled state.

The toggle was incorrectly reset to 'off' by initialization code that ran before the actual user settings were loaded from storage, leading to a visual discrepancy. This PR moves the logic to ensure the toggle state is set only after settings are restored.