### PR TITLE
release: 1.4.19 - add floating timer widget and error handling improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.19 (Apr 9, 2026)
+- Fix: Time Table now surfaces fetch errors when the Jira API key is invalid or expired (including when cached issues were shown first). `401`/`403` responses clear all cached Time Table data for that Jira base URL so stale rows are not left on screen after auth fails (see [#27](https://github.com/haydencbarnes/jira-time-tracker-ext/issues/27)).
+- Feature (experimental / Beta): **Floating Timer Widget** — optional bottom-right pill on web pages (enable under Experimental Features in Options). Shows issue key, elapsed time, play/pause, and a Beta badge; click the issue key to open the Jira issue or the time to open the full timer page (opens via the background script to avoid extension-page blocking) (see [#16](https://github.com/haydencbarnes/jira-time-tracker-ext/issues/16)).
+
 ## 1.4.18 (Apr 3, 2026)
 - Feature: Time Table column optionality and settings (see [#22](https://github.com/haydencbarnes/jira-time-tracker-ext/issues/22)).
   - Gear control in the table header (last column) opens **Time Table settings**: Custom JQL, optional **Status**, **Assignee**, **Total**, and **Comment** columns, and drag-and-drop column reorder (Jira ID and submit stay first/last).

--- a/content-script.css
+++ b/content-script.css
@@ -341,3 +341,140 @@
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.5);
   }
 }
+
+/* Floating timer widget */
+.jira-floating-timer-widget {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: auto;
+  max-width: calc(100vw - 32px);
+  box-sizing: border-box;
+  padding: 6px 8px;
+  border: 1px solid #dfe1e6;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #172b4d;
+  box-shadow: 0 4px 14px rgba(9, 30, 66, 0.18);
+  z-index: 2147483000;
+  font-family: Arial, sans-serif;
+}
+
+.jira-floating-timer-widget.dark {
+  background: #141414;
+  border-color: #333333;
+  color: #e0e0e0;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.35);
+}
+
+.jira-floating-timer-widget-badge {
+  flex-shrink: 0;
+  padding: 2px 5px;
+  border-radius: 999px;
+  background: #ff6b35;
+  color: #ffffff;
+  font-size: 8px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  box-shadow: 0 1px 3px rgba(255, 107, 53, 0.3);
+}
+
+.jira-floating-timer-widget.dark .jira-floating-timer-widget-badge {
+  background: #ff8c42;
+  box-shadow: 0 1px 3px rgba(255, 140, 66, 0.4);
+}
+
+.jira-floating-timer-widget-issue,
+.jira-floating-timer-widget-value,
+.jira-floating-timer-widget-icon {
+  appearance: none;
+  border: none;
+  background: transparent;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.jira-floating-timer-widget-time {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  color: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.jira-floating-timer-widget-issue {
+  padding: 0;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  opacity: 0.78;
+  letter-spacing: 0.02em;
+}
+
+.jira-floating-timer-widget-value {
+  padding: 0;
+  color: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.jira-floating-timer-widget-separator {
+  opacity: 0.45;
+}
+
+.jira-floating-timer-widget-issue:hover,
+.jira-floating-timer-widget-value:hover {
+  color: #0052cc;
+}
+
+.jira-floating-timer-widget.dark .jira-floating-timer-widget-issue:hover,
+.jira-floating-timer-widget.dark .jira-floating-timer-widget-value:hover {
+  color: #4690dd;
+}
+
+.jira-floating-timer-widget-icon {
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 999px;
+  background: #0052cc;
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.jira-floating-timer-widget-icon svg {
+  width: 11px;
+  height: 11px;
+  display: block;
+  fill: currentColor;
+}
+
+.jira-floating-timer-widget-icon:hover {
+  background: #0065ff;
+}
+
+.jira-floating-timer-widget.dark .jira-floating-timer-widget-icon {
+  background: #4690dd;
+  color: #141414;
+}
+
+.jira-floating-timer-widget.dark .jira-floating-timer-widget-icon:hover {
+  background: #5e9fe3;
+}

--- a/floating-timer-widget.js
+++ b/floating-timer-widget.js
@@ -1,0 +1,410 @@
+(function () {
+  if (window.__jiraFloatingTimerWidgetInitialized) return;
+  window.__jiraFloatingTimerWidgetInitialized = true;
+
+  class FloatingTimerWidget {
+    constructor() {
+      this.widget = null;
+      this.timerText = null;
+      this.issueText = null;
+      this.issueSeparator = null;
+      this.timerValue = null;
+      this.toggleButton = null;
+      this.interval = null;
+      this.settings = null;
+      this.issueKey = '';
+      this.seconds = 0;
+      this.isRunning = false;
+      this.lastUpdated = null;
+      this.themeMediaQuery = null;
+      this.boundSystemThemeListener = this.applyTheme.bind(this);
+      this.boundStorageListener = this.handleStorageChange.bind(this);
+      this.boundMessageListener = this.handleMessage.bind(this);
+
+      this.init();
+    }
+
+    async init() {
+      this.settings = await this.readSettings();
+      await this.syncTimerState();
+      this.updateVisibility();
+
+      chrome.storage.onChanged.addListener(this.boundStorageListener);
+      chrome.runtime.onMessage.addListener(this.boundMessageListener);
+    }
+
+    readSettings() {
+      return new Promise((resolve) => {
+        chrome.storage.sync.get({
+          baseUrl: '',
+          experimentalFeatures: false,
+          floatingTimerWidgetEnabled: false,
+          followSystemTheme: true,
+          darkMode: false
+        }, resolve);
+      });
+    }
+
+    readTimerState() {
+      return new Promise((resolve) => {
+        chrome.storage.sync.get({
+          issueKey: '',
+          timerSeconds: 0,
+          timerIsRunning: false,
+          timerLastUpdated: null
+        }, resolve);
+      });
+    }
+
+    writeTimerState(nextState) {
+      return new Promise((resolve) => {
+        chrome.storage.sync.set(nextState, () => resolve());
+      });
+    }
+
+    clearTimerState() {
+      return new Promise((resolve) => {
+        chrome.storage.sync.remove(['timerSeconds', 'timerIsRunning', 'timerLastUpdated'], () => resolve());
+      });
+    }
+
+    shouldShow() {
+      return !!(this.settings?.experimentalFeatures && this.settings?.floatingTimerWidgetEnabled);
+    }
+
+    ensureWidget() {
+      if (this.widget) return;
+
+      const widget = document.createElement('div');
+      widget.className = 'jira-floating-timer-widget';
+      widget.innerHTML = `
+        <span class="jira-floating-timer-widget-badge">Beta</span>
+        <div class="jira-floating-timer-widget-time">
+          <button type="button" class="jira-floating-timer-widget-issue" title="Open Jira issue"></button>
+          <span class="jira-floating-timer-widget-separator" aria-hidden="true">&middot;</span>
+          <button type="button" class="jira-floating-timer-widget-value" title="Open full timer">0:00</button>
+        </div>
+        <button type="button" class="jira-floating-timer-widget-icon" data-action="toggle" title="Start timer" aria-label="Start timer"></button>
+      `;
+
+      widget.querySelector('[data-action="toggle"]').addEventListener('click', () => {
+        if (this.isRunning) {
+          this.pauseTimer();
+        } else {
+          this.startTimer();
+        }
+      });
+
+      widget.querySelector('.jira-floating-timer-widget-issue').addEventListener('click', () => {
+        this.openIssue();
+      });
+
+      widget.querySelector('.jira-floating-timer-widget-value').addEventListener('click', () => {
+        this.openFullTimer();
+      });
+
+      document.body.appendChild(widget);
+
+      this.widget = widget;
+      this.timerText = widget.querySelector('.jira-floating-timer-widget-time');
+      this.issueText = widget.querySelector('.jira-floating-timer-widget-issue');
+      this.issueSeparator = widget.querySelector('.jira-floating-timer-widget-separator');
+      this.timerValue = widget.querySelector('.jira-floating-timer-widget-value');
+      this.toggleButton = widget.querySelector('[data-action="toggle"]');
+
+      this.applyTheme();
+      this.render();
+    }
+
+    removeWidget() {
+      this.stopDisplayInterval();
+      this.detachThemeListener();
+      if (this.widget) {
+        this.widget.remove();
+        this.widget = null;
+        this.timerText = null;
+        this.issueText = null;
+        this.issueSeparator = null;
+        this.timerValue = null;
+        this.toggleButton = null;
+      }
+    }
+
+    updateVisibility() {
+      if (!this.shouldShow()) {
+        this.removeWidget();
+        return;
+      }
+
+      this.ensureWidget();
+      this.applyTheme();
+      this.render();
+      this.syncDisplayInterval();
+    }
+
+    handleMessage(message) {
+      if (!message || message.type !== 'SETTINGS_CHANGED') return;
+
+      if (typeof message.experimentalFeatures === 'boolean') {
+        this.settings.experimentalFeatures = message.experimentalFeatures;
+      }
+      if (typeof message.floatingTimerWidgetEnabled === 'boolean') {
+        this.settings.floatingTimerWidgetEnabled = message.floatingTimerWidgetEnabled;
+      }
+
+      this.updateVisibility();
+    }
+
+    async handleStorageChange(changes, namespace) {
+      if (namespace !== 'sync') return;
+
+      if (
+        changes.experimentalFeatures ||
+        changes.floatingTimerWidgetEnabled ||
+        changes.baseUrl ||
+        changes.followSystemTheme ||
+        changes.darkMode
+      ) {
+        this.settings = await this.readSettings();
+        this.updateVisibility();
+      }
+
+      if (changes.issueKey || changes.timerSeconds || changes.timerIsRunning || changes.timerLastUpdated) {
+        this.applyTimerStateFromChanges(changes);
+        this.render();
+        this.syncDisplayInterval();
+      }
+    }
+
+    applyStoredTimerState(state) {
+      this.issueKey = state.issueKey ? String(state.issueKey).trim().toUpperCase() : '';
+      this.seconds = Number.isFinite(state.timerSeconds) ? state.timerSeconds : 0;
+      this.isRunning = state.timerIsRunning === true;
+      this.lastUpdated = state.timerLastUpdated || null;
+
+      if (this.isRunning) {
+        this.seconds = this.getCurrentSeconds();
+        this.lastUpdated = Date.now();
+      }
+    }
+
+    async syncTimerState() {
+      const state = await this.readTimerState();
+      this.applyStoredTimerState(state);
+    }
+
+    getCurrentSeconds() {
+      if (!this.isRunning || !this.lastUpdated) {
+        return Math.max(0, this.seconds || 0);
+      }
+
+      const elapsedSeconds = Math.floor((Date.now() - this.lastUpdated) / 1000);
+      return Math.max(0, (this.seconds || 0) + Math.max(0, elapsedSeconds));
+    }
+
+    formatTimer(totalSeconds) {
+      const safeSeconds = Math.max(0, totalSeconds || 0);
+      const hours = Math.floor(safeSeconds / 3600);
+      const minutes = Math.floor((safeSeconds % 3600) / 60);
+      const seconds = safeSeconds % 60;
+      if (hours > 0) {
+        return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+      }
+      return `${minutes}:${String(seconds).padStart(2, '0')}`;
+    }
+
+    getToggleIconMarkup() {
+      if (this.isRunning) {
+        return `
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <rect x="6" y="5" width="4" height="14" rx="1"></rect>
+            <rect x="14" y="5" width="4" height="14" rx="1"></rect>
+          </svg>
+        `;
+      }
+
+      return `
+        <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M8 5.5v13l10-6.5z"></path>
+        </svg>
+      `;
+    }
+
+    getIssueUrl() {
+      if (!this.issueKey || !this.settings?.baseUrl) return '';
+
+      const hasProtocol = /^https?:\/\//i.test(this.settings.baseUrl);
+      const normalizedBaseUrl = hasProtocol
+        ? this.settings.baseUrl
+        : `https://${this.settings.baseUrl}`;
+
+      return `${normalizedBaseUrl.replace(/\/+$/, '')}/browse/${encodeURIComponent(this.issueKey)}`;
+    }
+
+    getTimerChangeValue(changes, key, defaultValue, fallbackValue) {
+      if (!(key in changes)) return fallbackValue;
+      return Object.prototype.hasOwnProperty.call(changes[key], 'newValue')
+        ? changes[key].newValue
+        : defaultValue;
+    }
+
+    applyTimerStateFromChanges(changes) {
+      this.applyStoredTimerState({
+        issueKey: this.getTimerChangeValue(changes, 'issueKey', '', this.issueKey),
+        timerSeconds: this.getTimerChangeValue(changes, 'timerSeconds', 0, this.seconds),
+        timerIsRunning: this.getTimerChangeValue(changes, 'timerIsRunning', false, this.isRunning),
+        timerLastUpdated: this.getTimerChangeValue(changes, 'timerLastUpdated', null, this.lastUpdated)
+      });
+    }
+
+    render() {
+      if (!this.widget || !this.issueText || !this.issueSeparator || !this.timerValue || !this.toggleButton) return;
+
+      const currentSeconds = this.getCurrentSeconds();
+      this.issueText.textContent = this.issueKey;
+      this.issueText.hidden = !this.issueKey;
+      this.issueSeparator.hidden = !this.issueKey;
+      this.timerValue.textContent = this.formatTimer(currentSeconds);
+      this.issueText.disabled = !this.issueKey;
+      this.toggleButton.innerHTML = this.getToggleIconMarkup();
+      const toggleTitle = this.isRunning
+        ? 'Pause timer'
+        : (currentSeconds > 0 ? 'Resume timer' : 'Start timer');
+      this.toggleButton.title = toggleTitle;
+      this.toggleButton.setAttribute('aria-label', toggleTitle);
+    }
+
+    syncDisplayInterval() {
+      if (!this.widget) {
+        this.stopDisplayInterval();
+        return;
+      }
+
+      if (!this.isRunning) {
+        this.stopDisplayInterval();
+        this.render();
+        return;
+      }
+
+      if (this.interval) return;
+
+      this.render();
+      this.interval = setInterval(() => {
+        this.render();
+      }, 1000);
+    }
+
+    stopDisplayInterval() {
+      if (this.interval) {
+        clearInterval(this.interval);
+        this.interval = null;
+      }
+    }
+
+    async startTimer() {
+      const currentSeconds = this.getCurrentSeconds();
+      const now = Date.now();
+
+      await this.writeTimerState({
+        timerSeconds: currentSeconds,
+        timerIsRunning: true,
+        timerLastUpdated: now
+      });
+
+      chrome.runtime.sendMessage({ action: 'startTimer', seconds: currentSeconds });
+
+      this.seconds = currentSeconds;
+      this.isRunning = true;
+      this.lastUpdated = now;
+      this.render();
+      this.syncDisplayInterval();
+    }
+
+    async pauseTimer() {
+      const currentSeconds = this.getCurrentSeconds();
+      const now = Date.now();
+
+      await this.writeTimerState({
+        timerSeconds: currentSeconds,
+        timerIsRunning: false,
+        timerLastUpdated: now
+      });
+
+      chrome.runtime.sendMessage({ action: 'stopTimer' });
+
+      this.seconds = currentSeconds;
+      this.isRunning = false;
+      this.lastUpdated = now;
+      this.render();
+      this.syncDisplayInterval();
+    }
+
+    async resetTimer() {
+      await this.clearTimerState();
+      chrome.runtime.sendMessage({ action: 'resetTimer' });
+
+      this.seconds = 0;
+      this.isRunning = false;
+      this.lastUpdated = null;
+      this.render();
+      this.syncDisplayInterval();
+    }
+
+    openFullTimer() {
+      this.openUrl(chrome.runtime.getURL('timerFeatureModule/timer.html'));
+    }
+
+    openIssue() {
+      const issueUrl = this.getIssueUrl();
+      if (!issueUrl) return;
+      this.openUrl(issueUrl);
+    }
+
+    openUrl(url) {
+      if (!url) return;
+      chrome.runtime.sendMessage({ action: 'openUrl', url });
+    }
+
+    applyTheme() {
+      if (!this.widget) return;
+
+      this.attachThemeListener();
+
+      const shouldUseDarkTheme = this.settings?.followSystemTheme !== false
+        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+        : this.settings?.darkMode === true;
+
+      this.widget.classList.toggle('dark', shouldUseDarkTheme);
+    }
+
+    attachThemeListener() {
+      if (this.settings?.followSystemTheme === false) {
+        this.detachThemeListener();
+        return;
+      }
+
+      if (!this.themeMediaQuery) {
+        this.themeMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+        if (typeof this.themeMediaQuery.addEventListener === 'function') {
+          this.themeMediaQuery.addEventListener('change', this.boundSystemThemeListener);
+        } else if (typeof this.themeMediaQuery.addListener === 'function') {
+          this.themeMediaQuery.addListener(this.boundSystemThemeListener);
+        }
+      }
+    }
+
+    detachThemeListener() {
+      if (!this.themeMediaQuery) return;
+
+      if (typeof this.themeMediaQuery.removeEventListener === 'function') {
+        this.themeMediaQuery.removeEventListener('change', this.boundSystemThemeListener);
+      } else if (typeof this.themeMediaQuery.removeListener === 'function') {
+        this.themeMediaQuery.removeListener(this.boundSystemThemeListener);
+      }
+
+      this.themeMediaQuery = null;
+    }
+  }
+
+  new FloatingTimerWidget();
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Jira Log Time",
-  "version": "1.4.18",
+  "version": "1.4.19",
   "description": "Log/Track your time in Jira in seconds!",
   "host_permissions": [
     "<all_urls>"
@@ -16,7 +16,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["jira-issue-detection.js"],
+      "js": ["jira-issue-detection.js", "floating-timer-widget.js"],
       "css": ["content-script.css"],
       "run_at": "document_idle"
     }

--- a/options.html
+++ b/options.html
@@ -568,7 +568,7 @@
                         <input type="checkbox" id="experimentalFeatures">
                         <span class="slider"></span>
                     </label>
-                    <span class="toggle-label">(Calendar Add-on, Side Panel + More Coming Soon!)</span>
+                    <span class="toggle-label">(Calendar Add-on, Side Panel, Floating Timer Widget + More Coming Soon!)</span>
                 </td>
             </tr>
             <tr id="sidePanelRow" style="display: none;">
@@ -579,6 +579,17 @@
                         <span class="slider"></span>
                     </label>
                     <span class="jira-popup-beta-badge">Beta</span>
+                </td>
+            </tr>
+            <tr id="floatingTimerWidgetRow" style="display: none;">
+                <td>Floating Timer Widget</td>
+                <td>
+                    <label class="toggle-switch">
+                        <input type="checkbox" id="floatingTimerWidgetToggle">
+                        <span class="slider"></span>
+                    </label>
+                    <span class="jira-popup-beta-badge">Beta</span>
+                    <span class="toggle-label">(Shows a bottom-right timer on web pages)</span>
                 </td>
             </tr>
             <tr>

--- a/options.js
+++ b/options.js
@@ -16,6 +16,8 @@
     const systemThemeToggle = document.getElementById('systemThemeToggle');
     const sidePanelToggle = document.getElementById('sidePanelToggle');
     const sidePanelRow = document.getElementById('sidePanelRow');
+    const floatingTimerWidgetToggle = document.getElementById('floatingTimerWidgetToggle');
+    const floatingTimerWidgetRow = document.getElementById('floatingTimerWidgetRow');
 
     // Add proper theme toggle functionality
     document.addEventListener('DOMContentLoaded', function() {
@@ -130,9 +132,14 @@
             });
         }
         sidePanelRow.style.display = this.checked ? 'table-row' : 'none';
+        floatingTimerWidgetRow.style.display = this.checked ? 'table-row' : 'none';
         if (!this.checked) {
             sidePanelToggle.checked = false;
-            chrome.storage.sync.set({ sidePanelEnabled: false });
+            floatingTimerWidgetToggle.checked = false;
+            chrome.storage.sync.set({
+                sidePanelEnabled: false,
+                floatingTimerWidgetEnabled: false
+            });
         }
     });
 
@@ -156,7 +163,8 @@
         const frequentWorklogDescription1 = document.getElementById('frequentWorklogDescription1').value;
         const frequentWorklogDescription2 = document.getElementById('frequentWorklogDescription2').value;
         const defaultPage = document.getElementById('defaultPage').value;
-        const sidePanelEnabled = sidePanelToggle.checked;
+        const sidePanelEnabled = experimentalFeatures && sidePanelToggle.checked;
+        const floatingTimerWidgetEnabled = experimentalFeatures && floatingTimerWidgetToggle.checked;
 
         chrome.storage.sync.set({
             jiraType,
@@ -168,7 +176,8 @@
             frequentWorklogDescription1,
             frequentWorklogDescription2,
             defaultPage: defaultPage,
-            sidePanelEnabled
+            sidePanelEnabled,
+            floatingTimerWidgetEnabled
         }, function () {
             // Notify all content scripts about experimental features change
             chrome.tabs.query({}, function(tabs) {
@@ -176,7 +185,8 @@
                     chrome.tabs.sendMessage(tab.id, {
                         type: 'SETTINGS_CHANGED',
                         experimentalFeatures: experimentalFeatures,
-                        issueDetectionEnabled: issueDetectionEnabled
+                        issueDetectionEnabled: issueDetectionEnabled,
+                        floatingTimerWidgetEnabled: floatingTimerWidgetEnabled
                     }, function(response) {
                         // Ignore errors for tabs that don't have content scripts
                         if (chrome.runtime.lastError) {
@@ -206,7 +216,8 @@
           frequentWorklogDescription2: '',
           defaultPage: 'popup.html',
           followSystemTheme: true,
-          sidePanelEnabled: false
+          sidePanelEnabled: false,
+          floatingTimerWidgetEnabled: false
         }, async function (items) {
           jiraTypeSelect.value = items.jiraType;
           document.getElementById('username').value = items.username;
@@ -222,6 +233,8 @@
 
           sidePanelRow.style.display = items.experimentalFeatures ? 'table-row' : 'none';
           sidePanelToggle.checked = items.experimentalFeatures && items.sidePanelEnabled;
+          floatingTimerWidgetRow.style.display = items.experimentalFeatures ? 'table-row' : 'none';
+          floatingTimerWidgetToggle.checked = items.experimentalFeatures && items.floatingTimerWidgetEnabled;
 
           jiraTypeSelect.dispatchEvent(new Event('change'));
         });

--- a/popup.js
+++ b/popup.js
@@ -226,11 +226,11 @@ function initGearPanel(options) {
             try {
                 const JIRA = await getSharedJira(options);
                 const issuesResponse = await JIRA.getIssues(0, options.jql);
-                const cacheKey = `issuesCache:${options.baseUrl}:${options.jql}`;
+                const cacheKey = getIssuesCacheKey(options);
                 chrome.storage.local.set({ [cacheKey]: { data: issuesResponse, ts: Date.now() } });
                 onFetchSuccess(issuesResponse, options);
             } catch (err) {
-                window.JiraErrorHandler.handleJiraError(err, 'Failed to fetch issues with new JQL', 'popup');
+                await handleTimeTableFetchError(err, options, 'Failed to fetch issues with new JQL');
             }
         } else {
             // Just redraw table with new column settings
@@ -241,7 +241,7 @@ function initGearPanel(options) {
 }
 
 function redrawCurrentTable(options) {
-    const cacheKey = `issuesCache:${options.baseUrl}:${options.jql}`;
+    const cacheKey = getIssuesCacheKey(options);
     chrome.storage.local.get([cacheKey], (items) => {
         const cached = items[cacheKey];
         if (cached && cached.data) {
@@ -376,6 +376,71 @@ async function getSharedJira(options) {
     return window._ttJiraPromise;
 }
 
+function getJiraErrorStatusCode(error) {
+    const statusMatch = error?.message?.match(/Error (\d+):/);
+    return statusMatch ? parseInt(statusMatch[1], 10) : null;
+}
+
+function isJiraAuthError(error) {
+    const statusCode = getJiraErrorStatusCode(error);
+    return statusCode === 401 || statusCode === 403;
+}
+
+function getIssuesCacheKey(options) {
+    return `issuesCache:${options.baseUrl}:${options.jql}`;
+}
+
+function removeTimeTableCacheEntries(baseUrl) {
+    return new Promise((resolve) => {
+        try {
+            chrome.storage.local.get(null, (items) => {
+                const prefix = baseUrl ? `issuesCache:${baseUrl}:` : 'issuesCache:';
+                const keys = Object.keys(items || {}).filter((key) => key.startsWith(prefix));
+
+                if (keys.length === 0) {
+                    resolve();
+                    return;
+                }
+
+                chrome.storage.local.remove(keys, () => resolve());
+            });
+        } catch (_) {
+            resolve();
+        }
+    });
+}
+
+function clearTimeTableRows(options) {
+    clearMessages();
+    drawIssuesTable({ data: [] }, options);
+}
+
+async function clearCachedTimeTableData(options) {
+    await removeTimeTableCacheEntries(options.baseUrl);
+    clearTimeTableRows(options);
+}
+
+function shouldShowPopupFetchError(error, showedCached) {
+    if (!showedCached) return true;
+
+    if (isJiraAuthError(error)) {
+        return true;
+    }
+
+    const message = (error?.message || '').toLowerCase();
+    return message.includes('fetch') || message.includes('network') || message.includes('cors');
+}
+
+async function handleTimeTableFetchError(error, options, defaultMessage, showedCached = false) {
+    if (isJiraAuthError(error)) {
+        await clearCachedTimeTableData(options);
+    }
+
+    if (shouldShowPopupFetchError(error, showedCached)) {
+        window.JiraErrorHandler.handleJiraError(error, defaultMessage, 'popup');
+    }
+}
+
 async function init(options) {
     console.log("Options received:", options);
 
@@ -391,7 +456,7 @@ async function init(options) {
         }
 
         // Try to show cached data immediately for instant popup
-        const cacheKey = `issuesCache:${options.baseUrl}:${options.jql}`;
+        const cacheKey = getIssuesCacheKey(options);
         let showedCached = false;
         
         try {
@@ -429,10 +494,7 @@ async function init(options) {
             onFetchSuccess(issuesResponse, options);
         } catch (error) {
             console.error('Error fetching issues:', error);
-            // Only show error if we didn't show cached data
-            if (!showedCached) {
-                window.JiraErrorHandler.handleJiraError(error, 'Failed to fetch issues from JIRA', 'popup');
-            }
+            await handleTimeTableFetchError(error, options, 'Failed to fetch issues from JIRA', showedCached);
         } finally {
             if (!showedCached) {
                 toggleVisibility('div[id=loader-container]');
@@ -445,6 +507,7 @@ async function init(options) {
 }
 
 function onFetchSuccess(issuesResponse, options) {
+    clearMessages();
     console.log("Fetched issues:", issuesResponse);
     drawIssuesTable(issuesResponse, options); // Pass options to the function
 }
@@ -1097,6 +1160,7 @@ async function toggleStar(issueId, options) {
 
     } catch (err) {
         console.error('Error fetching issues after star update:', err);
+        await handleTimeTableFetchError(err, options, 'Failed to refresh issues after updating star');
     }
 }
 

--- a/timerFeatureModule/background.js
+++ b/timerFeatureModule/background.js
@@ -34,11 +34,31 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     syncTime(request.seconds, request.isRunning);
   } else if (request.action === 'openSidePanel') {
     chrome.sidePanel.open({ windowId: sender.tab.windowId });
+  } else if (request.action === 'openUrl') {
+    openUrlInTab(request.url, sender);
   } else if (request.action === 'logWorklog') {
     handleWorklogRequest(request, sendResponse);
     return true; // Keep the message channel open for async response
   }
 });
+
+function openUrlInTab(url, sender) {
+  if (!url || typeof url !== 'string') return;
+
+  const createProperties = { url };
+  if (sender?.tab?.windowId) {
+    createProperties.windowId = sender.tab.windowId;
+    if (typeof sender.tab.index === 'number') {
+      createProperties.index = sender.tab.index + 1;
+    }
+  }
+
+  chrome.tabs.create(createProperties, () => {
+    if (chrome.runtime.lastError) {
+      console.error('Failed to open URL from background:', chrome.runtime.lastError.message);
+    }
+  });
+}
 
 async function handleWorklogRequest(request, sendResponse) {
   try {

--- a/timerFeatureModule/timer.js
+++ b/timerFeatureModule/timer.js
@@ -106,7 +106,6 @@ async function onDOMContentLoaded() {
     insertFrequentWorklogDescription(options);
 
     restoreTimerState();
-    syncTimeWithBackground();
 
     const themeToggle = document.getElementById('themeToggle');
     
@@ -160,6 +159,9 @@ async function onDOMContentLoaded() {
                 const manualDark = result.darkMode === true;
                 applyTheme(followSystem, manualDark);
             });
+        }
+        if (namespace === 'sync' && ('timerSeconds' in changes || 'timerIsRunning' in changes || 'timerLastUpdated' in changes)) {
+            applyTimerStateFromChanges(changes);
         }
         // no-op for experimentalFeatures; suggestions always enabled now
     });
@@ -537,32 +539,21 @@ function setupInputFocus(input) {
 }
 
 function toggleTimer() {
-  const startStopButton = document.getElementById('startStop');
-  const startStopIcon = document.getElementById('startStopIcon');
-  const timerAnimation = document.getElementById('timer-animation');
-
   if (isRunning) {
-    clearInterval(timer);
-    startStopIcon.textContent = 'play_arrow';
-    timerAnimation.style.display = 'none';
-    timerAnimation.classList.remove('active');
     chrome.runtime.sendMessage({ action: 'stopTimer' });
   } else {
-    timer = setInterval(updateTimer, 1000);
-    startStopIcon.textContent = 'pause';
-    timerAnimation.style.display = 'block';
-    timerAnimation.classList.add('active');
     chrome.runtime.sendMessage({ action: 'startTimer', seconds: seconds });
   }
 
   isRunning = !isRunning;
+  applyTimerRunningUi();
   saveTimerState();
 }
 
 function updateTimer() {
+  if (!isRunning) return;
   seconds++;
   updateTimerDisplay();
-  chrome.runtime.sendMessage({ action: 'syncTime', seconds: seconds, isRunning: isRunning });
   if (seconds % 5 === 0) {  // Save every 5 seconds
     saveTimerState();
   }
@@ -579,21 +570,82 @@ function updateTimerDisplay() {
 }
 
 function resetTimer() {
-  clearInterval(timer);
   isRunning = false;
   seconds = 0;
   updateTimerDisplay();
-  const startStopIcon = document.getElementById('startStopIcon');
-  const timerAnimation = document.getElementById('timer-animation');
-  startStopIcon.textContent = 'play_arrow';
-  timerAnimation.style.display = 'none';
-  timerAnimation.classList.remove('active');
+  applyTimerRunningUi();
   chrome.runtime.sendMessage({ action: 'resetTimer' });
   chrome.storage.sync.remove(['timerSeconds', 'timerIsRunning', 'timerLastUpdated']);
 }
 
 function pad(num) {
   return num.toString().padStart(2, '0');
+}
+
+function applyTimerRunningUi() {
+  const startStopIcon = document.getElementById('startStopIcon');
+  const timerAnimation = document.getElementById('timer-animation');
+  if (!startStopIcon || !timerAnimation) return;
+
+  if (isRunning) {
+    startStopIcon.textContent = 'pause';
+    timerAnimation.style.display = 'block';
+    timerAnimation.classList.add('active');
+    if (!timer) {
+      timer = setInterval(updateTimer, 1000);
+    }
+  } else {
+    clearInterval(timer);
+    timer = null;
+    startStopIcon.textContent = 'play_arrow';
+    timerAnimation.style.display = 'none';
+    timerAnimation.classList.remove('active');
+  }
+}
+
+function applyStoredTimerState(items) {
+  seconds = items.timerSeconds;
+  isRunning = items.timerIsRunning;
+
+  if (isRunning && items.timerLastUpdated) {
+    const elapsedSeconds = Math.floor((new Date().getTime() - items.timerLastUpdated) / 1000);
+    seconds += elapsedSeconds;
+  }
+
+  updateTimerDisplay();
+  applyTimerRunningUi();
+}
+
+function getTimerChangeValue(changes, key, defaultValue, fallbackValue) {
+  if (!(key in changes)) return fallbackValue;
+  return Object.prototype.hasOwnProperty.call(changes[key], 'newValue')
+    ? changes[key].newValue
+    : defaultValue;
+}
+
+function applyTimerStateFromChanges(changes) {
+  applyStoredTimerState({
+    timerSeconds: getTimerChangeValue(changes, 'timerSeconds', 0, seconds),
+    timerIsRunning: getTimerChangeValue(changes, 'timerIsRunning', false, isRunning),
+    timerLastUpdated: getTimerChangeValue(changes, 'timerLastUpdated', null, Date.now())
+  });
+}
+
+function loadTimerState(syncBackground = false) {
+  chrome.storage.sync.get({
+    timerSeconds: 0,
+    timerIsRunning: false,
+    timerLastUpdated: null
+  }, function(items) {
+    applyStoredTimerState(items);
+
+    if (!syncBackground) return;
+
+    chrome.runtime.sendMessage({ action: 'updateBadge', seconds: seconds, isRunning: isRunning });
+    if (isRunning) {
+      chrome.runtime.sendMessage({ action: 'startTimer', seconds: seconds });
+    }
+  });
 }
 
 // Handle editable time
@@ -841,42 +893,8 @@ function saveTimerState() {
 }
 
 function restoreTimerState() {
-  chrome.storage.sync.get({
-    timerSeconds: 0,
-    timerIsRunning: false,
-    timerLastUpdated: null
-  }, function(items) {
-    seconds = items.timerSeconds;
-    isRunning = items.timerIsRunning;
-
-    if (isRunning && items.timerLastUpdated) {
-      const elapsedSeconds = Math.floor((new Date().getTime() - items.timerLastUpdated) / 1000);
-      seconds += elapsedSeconds;
-    }
-
-    updateTimerDisplay();
-    chrome.runtime.sendMessage({ action: 'updateBadge', seconds: seconds, isRunning: isRunning });
-    const startStopIcon = document.getElementById('startStopIcon');
-    const timerAnimation = document.getElementById('timer-animation');
-    if (isRunning) {
-      timer = setInterval(updateTimer, 1000);
-      startStopIcon.textContent = 'pause';
-      timerAnimation.style.display = 'block';
-      timerAnimation.classList.add('active');
-      chrome.runtime.sendMessage({ action: 'startTimer', seconds: seconds });
-    } else {
-      startStopIcon.textContent = 'play_arrow';
-      timerAnimation.style.display = 'none';
-      timerAnimation.classList.remove('active');
-    }
-  });
+  loadTimerState(true);
 }
-
-
-function syncTimeWithBackground() {
-  chrome.runtime.sendMessage({ action: 'syncTime', seconds: seconds, isRunning: isRunning });
-}
-
 function restartTimerAnimation() {
   const timerAnimation = document.getElementById('timer-animation');
   if (timerAnimation.style.display === 'block') {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new always-injected content script and background-driven tab-opening behavior, which can impact page UX and messaging flows if misbehaving. Also changes Time Table error/caching behavior on `401/403`, which could unexpectedly clear cached data for a Jira base URL if status parsing is wrong.
> 
> **Overview**
> Adds an *experimental* **Floating Timer Widget** content script (with new styles) that renders a bottom-right timer pill on all pages when enabled, showing the current issue key/time and allowing play/pause plus quick links to the Jira issue and the full timer page.
> 
> Improves Time Table fetch error handling by centralizing cache-key logic, surfacing fetch/auth errors even when cached issues were shown first, and clearing cached Time Table entries + rows for a Jira base URL on `401/403` to avoid showing stale data.
> 
> Updates Options to include a Beta toggle for the floating widget under Experimental Features, bumps version to `1.4.19`, and adds a background `openUrl` message handler to open links via the service worker (used by the widget).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 492a67804fc513a813aa3eb38667b46333a9dd29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->