### PR TITLE
Release 1.4.20: floating timer pill reset (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.20 (Apr 11, 2026)
+- Feature (experimental / Beta): **Floating Timer Widget** — reset control on the pill clears stored timer fields and syncs the extension badge via the existing `resetTimer` path (see [#29](https://github.com/haydencbarnes/jira-time-tracker-ext/issues/29)).
+- Fix: Work item ID text on the floating timer pill inherits the pill foreground color so it stays visible in light mode.
+
 ## 1.4.19 (Apr 9, 2026)
 - Fix: Time Table now surfaces fetch errors when the Jira API key is invalid or expired (including when cached issues were shown first). `401`/`403` responses clear all cached Time Table data for that Jira base URL so stale rows are not left on screen after auth fails (see [#27](https://github.com/haydencbarnes/jira-time-tracker-ext/issues/27)).
 - Feature (experimental / Beta): **Floating Timer Widget** — optional bottom-right pill on web pages (enable under Experimental Features in Options). Shows issue key, elapsed time, play/pause, and a Beta badge; click the issue key to open the Jira issue or the time to open the full timer page (opens via the background script to avoid extension-page blocking) (see [#16](https://github.com/haydencbarnes/jira-time-tracker-ext/issues/16)).

--- a/content-script.css
+++ b/content-script.css
@@ -414,6 +414,7 @@
 
 .jira-floating-timer-widget-issue {
   padding: 0;
+  color: inherit;
   font-size: 11px;
   font-weight: 600;
   line-height: 1;
@@ -449,14 +450,17 @@
   height: 22px;
   padding: 0;
   border-radius: 999px;
-  background: #0052cc;
-  color: #ffffff;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   font-size: 10px;
   font-weight: 700;
   line-height: 1;
+}
+
+.jira-floating-timer-widget-icon:disabled {
+  cursor: default;
+  opacity: 0.5;
 }
 
 .jira-floating-timer-widget-icon svg {
@@ -466,15 +470,40 @@
   fill: currentColor;
 }
 
-.jira-floating-timer-widget-icon:hover {
+.jira-floating-timer-widget-reset {
+  background: rgba(9, 30, 66, 0.08);
+  color: #42526e;
+}
+
+.jira-floating-timer-widget-reset:hover:not(:disabled) {
+  background: rgba(222, 53, 11, 0.12);
+  color: #de350b;
+}
+
+.jira-floating-timer-widget-toggle {
+  background: #0052cc;
+  color: #ffffff;
+}
+
+.jira-floating-timer-widget-toggle:hover:not(:disabled) {
   background: #0065ff;
 }
 
-.jira-floating-timer-widget.dark .jira-floating-timer-widget-icon {
+.jira-floating-timer-widget.dark .jira-floating-timer-widget-reset {
+  background: rgba(255, 255, 255, 0.12);
+  color: #c1c7d0;
+}
+
+.jira-floating-timer-widget.dark .jira-floating-timer-widget-reset:hover:not(:disabled) {
+  background: rgba(255, 86, 48, 0.18);
+  color: #ff8f73;
+}
+
+.jira-floating-timer-widget.dark .jira-floating-timer-widget-toggle {
   background: #4690dd;
   color: #141414;
 }
 
-.jira-floating-timer-widget.dark .jira-floating-timer-widget-icon:hover {
+.jira-floating-timer-widget.dark .jira-floating-timer-widget-toggle:hover:not(:disabled) {
   background: #5e9fe3;
 }

--- a/floating-timer-widget.js
+++ b/floating-timer-widget.js
@@ -9,6 +9,7 @@
       this.issueText = null;
       this.issueSeparator = null;
       this.timerValue = null;
+      this.resetButton = null;
       this.toggleButton = null;
       this.interval = null;
       this.settings = null;
@@ -84,7 +85,12 @@
           <span class="jira-floating-timer-widget-separator" aria-hidden="true">&middot;</span>
           <button type="button" class="jira-floating-timer-widget-value" title="Open full timer">0:00</button>
         </div>
-        <button type="button" class="jira-floating-timer-widget-icon" data-action="toggle" title="Start timer" aria-label="Start timer"></button>
+        <button type="button" class="jira-floating-timer-widget-icon jira-floating-timer-widget-reset" data-action="reset" title="Reset timer" aria-label="Reset timer">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M12 5V1L7 6l5 5V7c3.31 0 6 2.69 6 6s-2.69 6-6 6-6-2.69-6-6H4c0 4.42 3.58 8 8 8s8-3.58 8-8-3.58-8-8-8z"></path>
+          </svg>
+        </button>
+        <button type="button" class="jira-floating-timer-widget-icon jira-floating-timer-widget-toggle" data-action="toggle" title="Start timer" aria-label="Start timer"></button>
       `;
 
       widget.querySelector('[data-action="toggle"]').addEventListener('click', () => {
@@ -93,6 +99,10 @@
         } else {
           this.startTimer();
         }
+      });
+
+      widget.querySelector('[data-action="reset"]').addEventListener('click', () => {
+        this.resetTimer();
       });
 
       widget.querySelector('.jira-floating-timer-widget-issue').addEventListener('click', () => {
@@ -110,6 +120,7 @@
       this.issueText = widget.querySelector('.jira-floating-timer-widget-issue');
       this.issueSeparator = widget.querySelector('.jira-floating-timer-widget-separator');
       this.timerValue = widget.querySelector('.jira-floating-timer-widget-value');
+      this.resetButton = widget.querySelector('[data-action="reset"]');
       this.toggleButton = widget.querySelector('[data-action="toggle"]');
 
       this.applyTheme();
@@ -126,6 +137,7 @@
         this.issueText = null;
         this.issueSeparator = null;
         this.timerValue = null;
+        this.resetButton = null;
         this.toggleButton = null;
       }
     }
@@ -258,14 +270,18 @@
     }
 
     render() {
-      if (!this.widget || !this.issueText || !this.issueSeparator || !this.timerValue || !this.toggleButton) return;
+      if (!this.widget || !this.issueText || !this.issueSeparator || !this.timerValue || !this.resetButton || !this.toggleButton) return;
 
       const currentSeconds = this.getCurrentSeconds();
+      const canReset = this.isRunning || currentSeconds > 0;
       this.issueText.textContent = this.issueKey;
       this.issueText.hidden = !this.issueKey;
       this.issueSeparator.hidden = !this.issueKey;
       this.timerValue.textContent = this.formatTimer(currentSeconds);
       this.issueText.disabled = !this.issueKey;
+      this.resetButton.disabled = !canReset;
+      this.resetButton.title = canReset ? 'Reset timer' : 'Timer already reset';
+      this.resetButton.setAttribute('aria-label', canReset ? 'Reset timer' : 'Timer already reset');
       this.toggleButton.innerHTML = this.getToggleIconMarkup();
       const toggleTitle = this.isRunning
         ? 'Pause timer'

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Jira Log Time",
-  "version": "1.4.19",
+  "version": "1.4.20",
   "description": "Log/Track your time in Jira in seconds!",
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
## Summary
Bumps extension to **1.4.20** and documents changes in CHANGELOG.

## Changes
- **Floating timer pill** ([#29](https://github.com/haydencbarnes/jira-time-tracker-ext/issues/29)): Add a reset control that calls the existing `resetTimer` / `clearTimerState` path and keeps play/pause styling distinct.
- **Light mode**: Work item ID on the pill uses inherited foreground color so it stays visible.

## Files
- `manifest.json` — version `1.4.20`
- `CHANGELOG.md`
- `floating-timer-widget.js`, `content-script.css`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the experimental floating timer widget UI/state reset behavior and a version bump, with minimal impact outside the content script/badge messaging path.
> 
> **Overview**
> Adds a **Reset** control to the experimental floating timer pill that clears stored timer state and triggers the existing background `resetTimer` message path to keep the extension badge in sync.
> 
> Refines floating pill styling by separating reset vs toggle button themes (including disabled/hover states) and ensuring the issue key text inherits the pill foreground color for light-mode visibility. Also bumps the extension version to `1.4.20` and updates the `CHANGELOG`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43668d5fc9b9393b3d5d635bb03722453c14d125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->