### PR TITLE
Refactor shared theme and worklog helpers

### DIFF
--- a/src/ts/cli.ts
+++ b/src/ts/cli.ts
@@ -1,6 +1,8 @@
 import './shared/jira-api';
 import { getErrorMessage } from './shared/jira-error-handler';
 import { getRequiredElement } from './shared/dom-utils';
+import { initializeStoredThemeControls } from './shared/theme-sync';
+import { buildWorklogStartedTimestamp } from './shared/worklog-time';
 import type {
   CliOptions,
   JiraApiClient,
@@ -29,85 +31,13 @@ interface CommandContext {
   meIdentifiers: MeIdentifiers;
 }
 
-interface ThemeStorageResult {
-  followSystemTheme?: boolean;
-  darkMode?: boolean;
-}
-
 // Theme init shared with other pages
 document.addEventListener('DOMContentLoaded', function () {
   const themeToggleElement = document.getElementById(
     'themeToggle'
   ) as HTMLButtonElement | null;
   if (!themeToggleElement) return;
-  const themeToggle = themeToggleElement;
-
-  function updateThemeButton(isDark: boolean): void {
-    const iconSpan = themeToggle.querySelector<HTMLElement>('.icon');
-    if (!iconSpan) return;
-    if (isDark) {
-      iconSpan.textContent = '☀️';
-      themeToggle.title = 'Switch to light mode';
-    } else {
-      iconSpan.textContent = '🌙';
-      themeToggle.title = 'Switch to dark mode';
-    }
-  }
-
-  function setTheme(isDark: boolean): void {
-    updateThemeButton(isDark);
-    if (isDark) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-    }
-  }
-
-  function applyTheme(followSystem: boolean, manualDark: boolean): void {
-    if (followSystem) {
-      const mql = window.matchMedia('(prefers-color-scheme: dark)');
-      setTheme(mql.matches);
-      mql.onchange = (e) => setTheme(e.matches);
-      window._systemThemeListener = mql;
-    } else {
-      if (window._systemThemeListener) {
-        window._systemThemeListener.onchange = null;
-        window._systemThemeListener = null;
-      }
-      setTheme(manualDark);
-    }
-  }
-
-  chrome.storage.sync.get(['followSystemTheme', 'darkMode'], function (result) {
-    const theme = result as ThemeStorageResult;
-    const followSystem = theme.followSystemTheme !== false;
-    const manualDark = theme.darkMode === true;
-    applyTheme(followSystem, manualDark);
-  });
-
-  themeToggle?.addEventListener('click', function () {
-    const isDark = !document.body.classList.contains('dark-mode');
-    updateThemeButton(isDark);
-    setTheme(isDark);
-    chrome.storage.sync.set({ darkMode: isDark, followSystemTheme: false });
-  });
-
-  chrome.storage.onChanged.addListener(function (changes, namespace) {
-    if (
-      namespace === 'sync' &&
-      ('followSystemTheme' in changes || 'darkMode' in changes)
-    ) {
-      chrome.storage.sync.get(
-        ['followSystemTheme', 'darkMode'],
-        function (result) {
-          const theme = result as ThemeStorageResult;
-          const followSystem = theme.followSystemTheme !== false;
-          const manualDark = theme.darkMode === true;
-          applyTheme(followSystem, manualDark);
-        }
-      );
-    }
-  });
+  initializeStoredThemeControls({ toggle: themeToggleElement });
 });
 
 document.addEventListener('DOMContentLoaded', onDOMContentLoaded);
@@ -650,10 +580,7 @@ async function handleCommand(raw: string, ctx: CommandContext): Promise<void> {
       return;
     }
 
-    const startedTime =
-      typeof JIRA.buildStartedTimestamp === 'function'
-        ? JIRA.buildStartedTimestamp(parsed.date)
-        : new Date(parsed.date || Date.now()).toISOString();
+    const startedTime = buildWorklogStartedTimestamp(parsed.date);
     await JIRA.updateWorklog(
       parsed.issueKey,
       parsed.seconds,

--- a/src/ts/jira-issue-detection.ts
+++ b/src/ts/jira-issue-detection.ts
@@ -1,4 +1,9 @@
 import { getErrorMessage } from './shared/jira-error-handler';
+import {
+  buildNoonWorklogStartedTimestamp,
+  isValidWorklogDuration,
+  parseWorklogDurationToSeconds,
+} from './shared/worklog-time';
 import type {
   BackgroundWorklogResponse,
   ExtensionSettings,
@@ -26,7 +31,7 @@ function isTextEntryElement(
   );
 }
 
-// JIRA Issue ID Detection and Time Tracking Content Script (stable)
+// JIRA Issue ID Detection and Time Tracking Content Script
 // Detects JIRA issue IDs on any page and provides a quick log-time popup
 
 class JiraIssueDetector {
@@ -668,9 +673,9 @@ class JiraIssueDetector {
         return;
       }
 
-      if (!this.validateTimeFormat(timeValue)) {
+      if (!isValidWorklogDuration(timeValue)) {
         this.showPopupError(
-          'Invalid time format. Use: 2h, 30m, 1d, or combinations like "2h 30m"'
+          'Invalid time format. Use values like 2h, 30m, 1d, or 1.5h.'
         );
         return;
       }
@@ -686,35 +691,6 @@ class JiraIssueDetector {
 
     // Focus time input
     timeInput.focus();
-  }
-
-  validateTimeFormat(timeStr: string): boolean {
-    // Check if time format is valid (e.g., 2h, 30m, 1d, 2h 30m)
-    const timePattern = /^(\d+[dhm]\s*)+$/i;
-    return timePattern.test(timeStr.trim());
-  }
-
-  convertTimeToSeconds(timeStr: string): number {
-    const timeUnits: Record<'d' | 'h' | 'm', number> = {
-      d: 60 * 60 * 24,
-      h: 60 * 60,
-      m: 60,
-    };
-
-    const regex = /(\d+)([dhm])/gi;
-    let match;
-    let totalSeconds = 0;
-
-    while ((match = regex.exec(timeStr)) !== null) {
-      const value = parseInt(match[1], 10);
-      const unit = match[2].toLowerCase() as keyof typeof timeUnits;
-      const multiplier = timeUnits[unit];
-      if (multiplier !== undefined) {
-        totalSeconds += value * multiplier;
-      }
-    }
-
-    return totalSeconds;
   }
 
   async logTime(
@@ -740,8 +716,8 @@ class JiraIssueDetector {
     submitBtn.disabled = true;
 
     try {
-      const timeInSeconds = this.convertTimeToSeconds(timeStr);
-      const startedTime = this.getStartedTime(dateStr);
+      const timeInSeconds = parseWorklogDurationToSeconds(timeStr);
+      const startedTime = buildNoonWorklogStartedTimestamp(dateStr);
 
       // Send message to background script to handle the API call
       const response = await new Promise<BackgroundWorklogResponse>(
@@ -804,21 +780,6 @@ class JiraIssueDetector {
       loading.classList.remove('show');
       submitBtn.disabled = false;
     }
-  }
-
-  getStartedTime(dateString: string): string {
-    if (!dateString) {
-      return new Date().toISOString();
-    }
-
-    const date = new Date(dateString);
-    if (isNaN(date.getTime())) {
-      return new Date().toISOString();
-    }
-
-    // Set to 12:00 PM of the selected date
-    date.setHours(12, 0, 0, 0);
-    return date.toISOString();
   }
 
   showPopupSuccess(message: string): void {

--- a/src/ts/options.ts
+++ b/src/ts/options.ts
@@ -2,10 +2,10 @@ import type {
   JiraType,
   OptionsPageSettings,
   SettingsChangedMessage,
-  ThemeSettings,
 } from './shared/types';
 
 import { getRequiredElement } from './shared/dom-utils';
+import { initializeStoredThemeControls } from './shared/theme-sync';
 
 function getRequiredSelector<T extends HTMLElement>(selector: string): T {
   const element = document.querySelector(selector);
@@ -96,99 +96,20 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
     }
   }
 
-  function updateThemeButton(
-    themeToggle: HTMLButtonElement,
-    isDark: boolean
-  ): void {
-    const iconSpan = themeToggle.querySelector<HTMLElement>('.icon');
-    if (!iconSpan) return;
-
-    if (isDark) {
-      iconSpan.textContent = '☀️';
-      themeToggle.title = 'Switch to light mode';
-    } else {
-      iconSpan.textContent = '🌙';
-      themeToggle.title = 'Switch to dark mode';
-    }
-  }
-
-  function setTheme(themeToggle: HTMLButtonElement, isDark: boolean): void {
-    updateThemeButton(themeToggle, isDark);
-    document.body.classList.toggle('dark-mode', isDark);
-  }
-
-  function applyTheme(
-    themeToggle: HTMLButtonElement,
-    followSystem: boolean,
-    manualDark: boolean
-  ): void {
-    if (followSystem) {
-      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      setTheme(themeToggle, mediaQuery.matches);
-      mediaQuery.onchange = (event) => setTheme(themeToggle, event.matches);
-      window._systemThemeListener = mediaQuery;
-      return;
-    }
-
-    if (window._systemThemeListener) {
-      window._systemThemeListener.onchange = null;
-      window._systemThemeListener = null;
-    }
-
-    setTheme(themeToggle, manualDark);
-  }
-
   function initThemeControls(): void {
     document.addEventListener('DOMContentLoaded', async () => {
       const themeToggle = getRequiredElement<HTMLButtonElement>('themeToggle');
-      const themeSettings = await getSyncStorage<ThemeSettings>({
-        followSystemTheme: true,
-        darkMode: false,
-      });
-      const followSystem = themeSettings.followSystemTheme !== false;
-      const manualDark = themeSettings.darkMode === true;
-
-      applyTheme(themeToggle, followSystem, manualDark);
-      systemThemeToggle.checked = followSystem;
-
-      themeToggle.addEventListener('click', async () => {
-        const isDark = !document.body.classList.contains('dark-mode');
-        setTheme(themeToggle, isDark);
-        await setSyncStorage({ darkMode: isDark, followSystemTheme: false });
-        systemThemeToggle.checked = false;
+      initializeStoredThemeControls({
+        toggle: themeToggle,
+        onSettingsApplied: (settings) => {
+          systemThemeToggle.checked = settings.followSystemTheme;
+        },
       });
 
       systemThemeToggle.addEventListener('change', async () => {
-        const nextFollowSystem = systemThemeToggle.checked;
-        await setSyncStorage({ followSystemTheme: nextFollowSystem });
-        const latestTheme = await getSyncStorage<
-          Pick<ThemeSettings, 'darkMode'>
-        >({
-          darkMode: false,
+        await setSyncStorage({
+          followSystemTheme: systemThemeToggle.checked,
         });
-        applyTheme(
-          themeToggle,
-          nextFollowSystem,
-          latestTheme.darkMode === true
-        );
-      });
-
-      chrome.storage.onChanged.addListener((changes, namespace) => {
-        if (
-          namespace === 'sync' &&
-          ('followSystemTheme' in changes || 'darkMode' in changes)
-        ) {
-          void getSyncStorage<ThemeSettings>({
-            followSystemTheme: true,
-            darkMode: false,
-          }).then((latestThemeSettings) => {
-            const latestFollowSystem =
-              latestThemeSettings.followSystemTheme !== false;
-            const latestManualDark = latestThemeSettings.darkMode === true;
-            applyTheme(themeToggle, latestFollowSystem, latestManualDark);
-            systemThemeToggle.checked = latestFollowSystem;
-          });
-        }
       });
     });
   }

--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -1,6 +1,14 @@
 import './shared/jira-api';
 import { getErrorMessage } from './shared/jira-error-handler';
 import './shared/worklog-suggestions';
+import { initializeStoredThemeControls } from './shared/theme-sync';
+import {
+  buildWorklogStartedTimestamp,
+  getWorklogDurationValidationMessage,
+  isValidWorklogDuration,
+  parseWorklogDurationToSeconds,
+  sumWorklogSeconds,
+} from './shared/worklog-time';
 import type {
   JiraApiClient,
   JiraIssue,
@@ -109,69 +117,10 @@ function normalizeColumnOrder(stored: unknown): ColumnId[] {
 document.addEventListener('DOMContentLoaded', function () {
   const themeToggle = document.getElementById('themeToggle');
   if (!themeToggle) return;
-
-  function applyTheme(followSystem: boolean, manualDark: boolean) {
-    if (followSystem) {
-      const mql = window.matchMedia('(prefers-color-scheme: dark)');
-      setTheme(mql.matches);
-      mql.onchange = (e: MediaQueryListEvent) => setTheme(e.matches);
-      window._systemThemeListener = mql;
-    } else {
-      if (window._systemThemeListener) {
-        window._systemThemeListener.onchange = null;
-        window._systemThemeListener = null;
-      }
-      setTheme(manualDark);
-    }
-  }
-  function setTheme(isDark: boolean) {
-    updateThemeButton(isDark);
-    if (isDark) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-    }
-  }
-  chrome.storage.sync.get(['followSystemTheme', 'darkMode'], function (result) {
-    const followSystem = result.followSystemTheme !== false;
-    const manualDark = result.darkMode === true;
-    applyTheme(followSystem, manualDark);
-  });
-  themeToggle.addEventListener('click', function () {
-    const isDark = !document.body.classList.contains('dark-mode');
-    updateThemeButton(isDark);
-    setTheme(isDark);
-    chrome.storage.sync.set({ darkMode: isDark, followSystemTheme: false });
-  });
-  chrome.storage.onChanged.addListener(function (changes, namespace) {
-    if (
-      namespace === 'sync' &&
-      ('followSystemTheme' in changes || 'darkMode' in changes)
-    ) {
-      chrome.storage.sync.get(
-        ['followSystemTheme', 'darkMode'],
-        function (result) {
-          const followSystem = result.followSystemTheme !== false;
-          const manualDark = result.darkMode === true;
-          applyTheme(followSystem, manualDark);
-        }
-      );
-    }
+  initializeStoredThemeControls({
+    toggle: themeToggle as HTMLButtonElement,
   });
 });
-
-function updateThemeButton(isDark: boolean) {
-  const themeToggle = document.getElementById('themeToggle');
-  const iconSpan = themeToggle?.querySelector('.icon');
-  if (!themeToggle || !iconSpan) return;
-  if (isDark) {
-    iconSpan.textContent = '☀️';
-    themeToggle.title = 'Switch to light mode';
-  } else {
-    iconSpan.textContent = '🌙';
-    themeToggle.title = 'Switch to dark mode';
-  }
-}
 
 // ===== Main init =====
 document.addEventListener('DOMContentLoaded', onDOMContentLoaded);
@@ -700,11 +649,7 @@ function getWorklog(issueId: string, JIRA: JiraApiClient) {
 }
 
 function sumWorklogs(worklogs: JiraWorklog[]) {
-  if (!Array.isArray(worklogs)) return '0 hrs';
-  const totalSeconds = worklogs.reduce(
-    (total, log) => total + log.timeSpentSeconds,
-    0
-  );
+  const totalSeconds = sumWorklogSeconds(worklogs);
   const totalHours = (totalSeconds / 3600).toFixed(1);
   return `${totalHours} hrs`;
 }
@@ -781,15 +726,16 @@ async function logTimeClick(evt: Event) {
     return;
   }
 
-  const timeMatches = timeInput.value.match(/[0-9]{1,4}[dhm]/g);
-  if (!timeMatches) {
+  if (!isValidWorklogDuration(timeInput.value, { allowWeeks: true })) {
     displayError(
-      'Invalid time format. Please use:\n• Hours: 2h, 1.5h\n• Minutes: 30m, 45m\n• Days: 1d, 0.5d\n\nExamples: "2h 30m", "1d", "45m"'
+      getWorklogDurationValidationMessage({ allowWeeks: true })
     );
     return;
   }
 
-  const timeSpentSeconds = convertTimeToSeconds(timeInput.value);
+  const timeSpentSeconds = parseWorklogDurationToSeconds(timeInput.value, {
+    allowWeeks: true,
+  });
   if (isNaN(timeSpentSeconds) || timeSpentSeconds <= 0) {
     displayError(
       'Invalid time value. Please enter a positive time amount using valid units (d=days, h=hours, m=minutes).'
@@ -803,7 +749,7 @@ async function logTimeClick(evt: Event) {
     loader.style.display = 'block';
   }
 
-  const startedTime = getStartedTime(dateInput.value);
+  const startedTime = buildWorklogStartedTimestamp(dateInput.value);
 
   try {
     const options = await new Promise<PopupOptions>((resolve, reject) =>
@@ -867,28 +813,6 @@ async function logTimeClick(evt: Event) {
       showErrorAnimation(issueId);
     }
   }
-}
-
-function convertTimeToSeconds(timeStr: string): number {
-  const timeUnits: Record<'d' | 'h' | 'm' | 'w', number> = {
-    d: 60 * 60 * 24,
-    h: 60 * 60,
-    m: 60,
-    w: 60 * 60 * 24 * 5,
-  };
-
-  const regex = /(\d+)([wdhm])/g;
-  let match: RegExpExecArray | null;
-  let totalSeconds = 0;
-
-  while ((match = regex.exec(timeStr)) !== null) {
-    const value = parseInt(match[1], 10);
-    const unit = match[2] as keyof typeof timeUnits;
-    const mult = timeUnits[unit];
-    if (mult != null) totalSeconds += value * mult;
-  }
-
-  return totalSeconds;
 }
 
 /***************
@@ -1363,47 +1287,6 @@ Date.prototype.toDateInputValue = function () {
   local.setMinutes(this.getMinutes() - this.getTimezoneOffset());
   return local.toJSON().slice(0, 10);
 };
-
-function getStartedTime(dateString: string) {
-  // Parse the input date string
-  const [year, month, day] = dateString.split('-').map(Number);
-
-  // Create a date object using the local timezone
-  const date = new Date(year, month - 1, day);
-  const now = new Date();
-
-  // Combine the input date with the current time
-  date.setHours(
-    now.getHours(),
-    now.getMinutes(),
-    now.getSeconds(),
-    now.getMilliseconds()
-  );
-
-  // Calculate timezone offset
-  const tzo = -date.getTimezoneOffset();
-  const dif = tzo >= 0 ? '+' : '-';
-
-  // Format the date string
-  const formattedDate =
-    `${date.getFullYear()}-` +
-    `${pad(date.getMonth() + 1)}-` +
-    `${pad(date.getDate())}T` +
-    `${pad(date.getHours())}:` +
-    `${pad(date.getMinutes())}:` +
-    `${pad(date.getSeconds())}.` +
-    `${pad(date.getMilliseconds(), 3)}` +
-    `${dif}${pad(Math.abs(Math.floor(tzo / 60)))}:${pad(Math.abs(tzo % 60))}`;
-
-  console.log('Input date string:', dateString);
-  console.log('Formatted start time:', formattedDate);
-
-  return formattedDate;
-}
-
-function pad(num: number, width = 2) {
-  return String(Math.abs(Math.floor(num))).padStart(width, '0');
-}
 
 function insertFrequentWorklogDescription(options: PopupOptions) {
   const descriptionFields = document.querySelectorAll<HTMLInputElement>(

--- a/src/ts/search.ts
+++ b/src/ts/search.ts
@@ -3,10 +3,16 @@ import './shared/jira-error-handler';
 import './shared/worklog-suggestions';
 import { getRequiredElement } from './shared/dom-utils';
 import {
-  autocomplete,
-  bindInfiniteIssuesScroll,
+  loadProjectIssuesIntoAutocomplete,
   setupProjectIssueAutocomplete,
 } from './shared/jira-project-issue-autocomplete';
+import { initializeStoredThemeControls } from './shared/theme-sync';
+import {
+  buildWorklogStartedTimestamp,
+  getWorklogDurationValidationMessage,
+  isValidWorklogDuration,
+  parseWorklogDurationToSeconds,
+} from './shared/worklog-time';
 import type {
   JiraApiClient,
   SearchOptions,
@@ -18,82 +24,8 @@ document.addEventListener('DOMContentLoaded', function () {
     'themeToggle'
   ) as HTMLButtonElement | null;
   if (!themeToggleElement) return;
-  const themeToggle = themeToggleElement;
-
-  // Unified theme logic
-  function applyTheme(followSystem: boolean, manualDark: boolean): void {
-    if (followSystem) {
-      const mql = window.matchMedia('(prefers-color-scheme: dark)');
-      setTheme(mql.matches);
-      mql.onchange = (e) => setTheme(e.matches);
-      window._systemThemeListener = mql;
-    } else {
-      if (window._systemThemeListener) {
-        window._systemThemeListener.onchange = null;
-        window._systemThemeListener = null;
-      }
-      setTheme(manualDark);
-    }
-  }
-  function setTheme(isDark: boolean): void {
-    updateThemeButton(isDark);
-    if (isDark) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-    }
-  }
-  // Load settings and apply theme
-  chrome.storage.sync.get(['followSystemTheme', 'darkMode'], function (result) {
-    const theme = result as { followSystemTheme?: boolean; darkMode?: boolean };
-    const followSystem = theme.followSystemTheme !== false; // default true
-    const manualDark = theme.darkMode === true;
-    applyTheme(followSystem, manualDark);
-  });
-  // Theme button disables system-following and sets manual override
-  themeToggle.addEventListener('click', function () {
-    const isDark = !document.body.classList.contains('dark-mode');
-    updateThemeButton(isDark);
-    setTheme(isDark);
-    chrome.storage.sync.set({ darkMode: isDark, followSystemTheme: false });
-  });
-  // Listen for changes from other tabs/options
-  chrome.storage.onChanged.addListener(function (changes, namespace) {
-    if (
-      namespace === 'sync' &&
-      ('followSystemTheme' in changes || 'darkMode' in changes)
-    ) {
-      chrome.storage.sync.get(
-        ['followSystemTheme', 'darkMode'],
-        function (result) {
-          const theme = result as {
-            followSystemTheme?: boolean;
-            darkMode?: boolean;
-          };
-          const followSystem = theme.followSystemTheme !== false;
-          const manualDark = theme.darkMode === true;
-          applyTheme(followSystem, manualDark);
-        }
-      );
-    }
-  });
+  initializeStoredThemeControls({ toggle: themeToggleElement });
 });
-
-// Function to update the theme button icon
-function updateThemeButton(isDark: boolean): void {
-  const themeToggle = document.getElementById(
-    'themeToggle'
-  ) as HTMLButtonElement | null;
-  const iconSpan = themeToggle?.querySelector<HTMLElement>('.icon');
-  if (!themeToggle || !iconSpan) return;
-  if (isDark) {
-    iconSpan.textContent = '☀️';
-    themeToggle.title = 'Switch to light mode';
-  } else {
-    iconSpan.textContent = '🌙';
-    themeToggle.title = 'Switch to dark mode';
-  }
-}
 
 document.addEventListener('DOMContentLoaded', onDOMContentLoaded);
 
@@ -174,25 +106,12 @@ async function init(options: SearchOptions): Promise<void> {
         },
       },
       onProjectSelectedFromDropdown: async ({ selectedProject, ctx }) => {
-        const { JIRA: jira, replaceIssueInput, issueInputRef, issueList } = ctx;
-        const jql = `project = ${selectedProject.key}`;
-        replaceIssueInput();
-        const page = await jira.getIssuesPage(jql, null, 100);
-        const issueItems = page.data.map(
-          (i) => `${i.key}: ${i.fields.summary || ''}`
-        );
-        autocomplete(issueInputRef.current, issueItems, issueList, null, {
+        await loadProjectIssuesIntoAutocomplete({
+          ctx,
+          selectedProject,
+          formatIssueRow: (i) => `${i.key}: ${i.fields.summary || ''}`,
           getJiraForSuggestions: () => JIRA,
         });
-        bindInfiniteIssuesScroll(
-          issueList,
-          issueItems,
-          jql,
-          jira,
-          issueInputRef.current,
-          (i) => `${i.key}: ${i.fields.summary || ''}`,
-          page.nextCursor
-        );
       },
     });
 
@@ -241,11 +160,8 @@ async function logTimeClick(evt: Event): Promise<void> {
   }
 
   // Validate time format
-  const timeMatches = timeSpent.match(/[0-9]{1,4}[dhm]/g);
-  if (!timeMatches) {
-    displayError(
-      'Invalid time format. Please use:\n• Hours: 2h, 1.5h\n• Minutes: 30m, 45m\n• Days: 1d, 0.5d\n\nExamples: "2h 30m", "1d", "45m"'
-    );
+  if (!isValidWorklogDuration(timeSpent)) {
+    displayError(getWorklogDurationValidationMessage());
     return;
   }
 
@@ -272,11 +188,8 @@ async function logTimeClick(evt: Event): Promise<void> {
           options.username as string,
           options.apiToken as string
         );
-        const startedTime =
-          typeof JIRA.buildStartedTimestamp === 'function'
-            ? JIRA.buildStartedTimestamp(date)
-            : new Date(date).toISOString();
-        const timeSpentSeconds = convertTimeToSeconds(timeSpent);
+        const startedTime = buildWorklogStartedTimestamp(date);
+        const timeSpentSeconds = parseWorklogDurationToSeconds(timeSpent);
 
         console.log({
           issueKey,
@@ -309,26 +222,6 @@ async function logTimeClick(evt: Event): Promise<void> {
       }
     }
   );
-}
-
-function convertTimeToSeconds(timeStr: string): number {
-  const timeUnits = {
-    d: 60 * 60 * 24,
-    h: 60 * 60,
-    m: 60,
-  } as const;
-
-  const regex = /(\d+)([dhm])/g;
-  let match;
-  let totalSeconds = 0;
-
-  while ((match = regex.exec(timeStr)) !== null) {
-    const value = parseInt(match[1], 10);
-    const unit = match[2] as keyof typeof timeUnits;
-    totalSeconds += value * timeUnits[unit];
-  }
-
-  return totalSeconds;
 }
 
 function displayError(message: string): void {

--- a/src/ts/shared/jira-api.ts
+++ b/src/ts/shared/jira-api.ts
@@ -88,7 +88,6 @@ async function JiraAPI(
     isIssueKeyLike,
     extractIssueKey,
     validateIssueMatchesProject,
-    buildStartedTimestamp,
   };
 
   async function login(): Promise<JiraLoginResponse> {
@@ -354,36 +353,6 @@ async function JiraAPI(
       console.warn('Failed to invalidate worklog cache', e);
     }
     return result;
-  }
-
-  // Build a started timestamp using the current local time of day on the given date (or today)
-  function buildStartedTimestamp(dateInput?: string | Date | null): string {
-    try {
-      const baseDate = dateInput ? new Date(dateInput) : new Date();
-      const now = new Date();
-      baseDate.setHours(
-        now.getHours(),
-        now.getMinutes(),
-        now.getSeconds(),
-        now.getMilliseconds()
-      );
-      const tzo = -baseDate.getTimezoneOffset();
-      const dif = tzo >= 0 ? '+' : '-';
-      const pad = (n: number, s = 2) => String(n).padStart(s, '0');
-      return (
-        `${baseDate.getFullYear()}-` +
-        `${pad(baseDate.getMonth() + 1)}-` +
-        `${pad(baseDate.getDate())}T` +
-        `${pad(baseDate.getHours())}:` +
-        `${pad(baseDate.getMinutes())}:` +
-        `${pad(baseDate.getSeconds())}.` +
-        `${pad(baseDate.getMilliseconds(), 3)}` +
-        `${dif}${pad(Math.abs(Math.floor(tzo / 60)))}:${pad(Math.abs(tzo % 60))}`
-      );
-    } catch {
-      // Fallback to ISO string if anything goes wrong
-      return new Date().toISOString();
-    }
   }
 
   function parseDate(date: string | number | Date): string {

--- a/src/ts/shared/jira-project-issue-autocomplete.ts
+++ b/src/ts/shared/jira-project-issue-autocomplete.ts
@@ -276,8 +276,18 @@ export function bindInfiniteIssuesScroll(
 ): void {
   let loadingMore = false;
   let nextCursor = initialNextCursor;
+  const boundIssueList = issueList as HTMLUListElement & {
+    _ttInfiniteIssuesScrollHandler?: EventListener;
+  };
 
-  issueList.addEventListener('scroll', () => {
+  if (boundIssueList._ttInfiniteIssuesScrollHandler) {
+    issueList.removeEventListener(
+      'scroll',
+      boundIssueList._ttInfiniteIssuesScrollHandler
+    );
+  }
+
+  const handleScroll: EventListener = () => {
     void (async () => {
       if (loadingMore || !nextCursor) return;
       const nearBottom =
@@ -293,7 +303,55 @@ export function bindInfiniteIssuesScroll(
       issueInput.dispatchEvent(evt);
       loadingMore = false;
     })();
-  });
+  };
+
+  boundIssueList._ttInfiniteIssuesScrollHandler = handleScroll;
+  issueList.addEventListener('scroll', handleScroll);
+}
+
+export interface IssueAutocompleteProjectLoadArgs {
+  ctx: ProjectIssueAutocompleteContext;
+  selectedProject: JiraProjectsResponse['data'][number];
+  formatIssueRow: (issue: JiraIssue) => string;
+  getJiraForSuggestions: () => JiraApiClient | null;
+  onIssueSelected?: (selectedIssue: string) => void;
+}
+
+export async function loadProjectIssuesIntoAutocomplete(
+  args: IssueAutocompleteProjectLoadArgs
+): Promise<void> {
+  const {
+    ctx,
+    selectedProject,
+    formatIssueRow,
+    getJiraForSuggestions,
+    onIssueSelected,
+  } = args;
+  const { JIRA, replaceIssueInput, issueInputRef, issueList } = ctx;
+  const jql = `project = ${selectedProject.key}`;
+
+  replaceIssueInput();
+  const page = await JIRA.getIssuesPage(jql, null, 100);
+  const issueItems = page.data.map((issue) => formatIssueRow(issue));
+
+  autocomplete(
+    issueInputRef.current,
+    issueItems,
+    issueList,
+    onIssueSelected ?? null,
+    {
+      getJiraForSuggestions,
+    }
+  );
+  bindInfiniteIssuesScroll(
+    issueList,
+    issueItems,
+    jql,
+    JIRA,
+    issueInputRef.current,
+    formatIssueRow,
+    page.nextCursor
+  );
 }
 
 export interface ProjectIssueAutocompleteBehavior {

--- a/src/ts/shared/theme-sync.ts
+++ b/src/ts/shared/theme-sync.ts
@@ -1,0 +1,116 @@
+import type { ThemeSettings } from './types';
+
+interface ThemeSyncOptions {
+  toggle?: HTMLButtonElement | null;
+  afterInitialApply?: () => void;
+  onSettingsApplied?: (settings: ThemeSettings) => void;
+}
+
+type ThemeStorageResult = {
+  followSystemTheme?: boolean;
+  darkMode?: boolean;
+};
+
+export function updateStandardThemeToggle(
+  toggle: HTMLButtonElement | null | undefined,
+  isDark: boolean
+): void {
+  const iconSpan = toggle?.querySelector<HTMLElement>('.icon');
+  if (!toggle || !iconSpan) return;
+
+  if (isDark) {
+    iconSpan.textContent = '☀️';
+    toggle.title = 'Switch to light mode';
+  } else {
+    iconSpan.textContent = '🌙';
+    toggle.title = 'Switch to dark mode';
+  }
+}
+
+function clearSystemThemeListener(): void {
+  if (window._systemThemeListener) {
+    window._systemThemeListener.onchange = null;
+    window._systemThemeListener = null;
+  }
+}
+
+function applyDarkMode(
+  isDark: boolean,
+  toggle?: HTMLButtonElement | null
+): void {
+  updateStandardThemeToggle(toggle, isDark);
+  document.body.classList.toggle('dark-mode', isDark);
+}
+
+export function applyThemeSettings(
+  settings: ThemeSettings,
+  toggle?: HTMLButtonElement | null
+): void {
+  clearSystemThemeListener();
+
+  if (settings.followSystemTheme) {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    applyDarkMode(mediaQuery.matches, toggle);
+    mediaQuery.onchange = (event) => applyDarkMode(event.matches, toggle);
+    window._systemThemeListener = mediaQuery;
+    return;
+  }
+
+  applyDarkMode(settings.darkMode, toggle);
+}
+
+export function readStoredThemeSettings(): Promise<ThemeSettings> {
+  return new Promise((resolve) => {
+    chrome.storage.sync.get(
+      ['followSystemTheme', 'darkMode'],
+      (result: ThemeStorageResult) =>
+        resolve({
+          followSystemTheme: result.followSystemTheme !== false,
+          darkMode: result.darkMode === true,
+        })
+    );
+  });
+}
+
+export async function applyStoredTheme(
+  toggle?: HTMLButtonElement | null,
+  onSettingsApplied?: (settings: ThemeSettings) => void
+): Promise<void> {
+  const settings = await readStoredThemeSettings();
+  applyThemeSettings(settings, toggle);
+  onSettingsApplied?.(settings);
+}
+
+export function initializeStoredThemeControls(
+  options: ThemeSyncOptions = {}
+): void {
+  const { toggle, afterInitialApply, onSettingsApplied } = options;
+
+  void applyStoredTheme(toggle, (settings) => {
+    onSettingsApplied?.(settings);
+    afterInitialApply?.();
+  });
+
+  toggle?.addEventListener('click', () => {
+    const nextDarkMode = !document.body.classList.contains('dark-mode');
+    const settings: ThemeSettings = {
+      followSystemTheme: false,
+      darkMode: nextDarkMode,
+    };
+    applyThemeSettings(settings, toggle);
+    onSettingsApplied?.(settings);
+    chrome.storage.sync.set({
+      darkMode: nextDarkMode,
+      followSystemTheme: false,
+    });
+  });
+
+  chrome.storage.onChanged.addListener((changes, namespace) => {
+    if (
+      namespace === 'sync' &&
+      ('followSystemTheme' in changes || 'darkMode' in changes)
+    ) {
+      void applyStoredTheme(toggle, onSettingsApplied);
+    }
+  });
+}

--- a/src/ts/shared/types.ts
+++ b/src/ts/shared/types.ts
@@ -120,7 +120,6 @@ export interface JiraApiClient {
   isIssueKeyLike(key: string): boolean;
   extractIssueKey(raw: string): string;
   validateIssueMatchesProject(issueKey: string, projectKey: string): boolean;
-  buildStartedTimestamp(dateInput?: string | Date | null): string;
 }
 
 export interface ThemeSettings {

--- a/src/ts/shared/worklog-time.ts
+++ b/src/ts/shared/worklog-time.ts
@@ -1,0 +1,175 @@
+import type { JiraWorklog } from './types';
+
+export interface WorklogDurationOptions {
+  allowWeeks?: boolean;
+}
+
+const BASE_WORKLOG_DURATION_SECONDS = {
+  d: 60 * 60 * 24,
+  h: 60 * 60,
+  m: 60,
+} as const;
+
+const WORKLOG_DURATION_SECONDS_WITH_WEEKS = {
+  w: 60 * 60 * 24 * 5,
+  ...BASE_WORKLOG_DURATION_SECONDS,
+} as const;
+
+function getAllowedDurationUnits(allowWeeks: boolean): string {
+  return allowWeeks ? 'wdhm' : 'dhm';
+}
+
+function getDurationUnitMap(allowWeeks: boolean) {
+  return allowWeeks
+    ? WORKLOG_DURATION_SECONDS_WITH_WEEKS
+    : BASE_WORKLOG_DURATION_SECONDS;
+}
+
+function parseDateInput(dateInput?: string | Date | null): Date | null {
+  if (!dateInput) return new Date();
+
+  if (dateInput instanceof Date) {
+    if (isNaN(dateInput.getTime())) return null;
+    return new Date(dateInput);
+  }
+
+  const trimmed = String(dateInput).trim();
+  if (!trimmed) return new Date();
+
+  const dateOnlyMatch = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (dateOnlyMatch) {
+    const [, year, month, day] = dateOnlyMatch;
+    return new Date(Number(year), Number(month) - 1, Number(day));
+  }
+
+  const parsed = new Date(trimmed);
+  return isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function formatDateWithOffset(date: Date): string {
+  const timezoneOffsetMinutes = -date.getTimezoneOffset();
+  const timezoneSign = timezoneOffsetMinutes >= 0 ? '+' : '-';
+  const pad = (value: number, width = 2) =>
+    String(Math.abs(Math.floor(value))).padStart(width, '0');
+
+  return (
+    `${date.getFullYear()}-` +
+    `${pad(date.getMonth() + 1)}-` +
+    `${pad(date.getDate())}T` +
+    `${pad(date.getHours())}:` +
+    `${pad(date.getMinutes())}:` +
+    `${pad(date.getSeconds())}.` +
+    `${pad(date.getMilliseconds(), 3)}` +
+    `${timezoneSign}${pad(Math.abs(Math.floor(timezoneOffsetMinutes / 60)))}:` +
+    `${pad(Math.abs(timezoneOffsetMinutes % 60))}`
+  );
+}
+
+export function isValidWorklogDuration(
+  input: string,
+  options: WorklogDurationOptions = {}
+): boolean {
+  const trimmed = input.trim();
+  if (!trimmed) return false;
+
+  const pattern = new RegExp(
+    `^(?:\\s*\\d+(?:\\.\\d+)?\\s*[${getAllowedDurationUnits(
+      options.allowWeeks === true
+    )}]\\s*)+$`,
+    'i'
+  );
+
+  return pattern.test(trimmed);
+}
+
+export function parseWorklogDurationToSeconds(
+  input: string,
+  options: WorklogDurationOptions = {}
+): number {
+  const allowWeeks = options.allowWeeks === true;
+  const units = getDurationUnitMap(allowWeeks);
+  const tokenPattern = new RegExp(
+    `(\\d+(?:\\.\\d+)?)\\s*([${getAllowedDurationUnits(allowWeeks)}])`,
+    'gi'
+  );
+
+  let totalSeconds = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenPattern.exec(input)) !== null) {
+    const value = parseFloat(match[1]);
+    const unit = match[2].toLowerCase() as keyof typeof units;
+    const secondsPerUnit = units[unit];
+    if (!Number.isNaN(value) && secondsPerUnit != null) {
+      totalSeconds += value * secondsPerUnit;
+    }
+  }
+
+  return Math.round(totalSeconds);
+}
+
+export function getWorklogDurationValidationMessage(
+  options: WorklogDurationOptions = {}
+): string {
+  const lines = [
+    'Invalid time format. Please use:',
+    '• Hours: 2h, 1.5h',
+    '• Minutes: 30m, 45m',
+    '• Days: 1d, 0.5d',
+  ];
+
+  if (options.allowWeeks === true) {
+    lines.push('• Weeks: 1w, 0.5w');
+  }
+
+  const examples = options.allowWeeks === true
+    ? 'Examples: "2h 30m", "1d", "45m", "1w 2d"'
+    : 'Examples: "2h 30m", "1d", "45m"';
+
+  return `${lines.join('\n')}\n\n${examples}`;
+}
+
+export function buildWorklogStartedTimestamp(
+  dateInput?: string | Date | null
+): string {
+  try {
+    const baseDate = parseDateInput(dateInput);
+    if (!baseDate) {
+      return new Date().toISOString();
+    }
+
+    const now = new Date();
+    baseDate.setHours(
+      now.getHours(),
+      now.getMinutes(),
+      now.getSeconds(),
+      now.getMilliseconds()
+    );
+
+    return formatDateWithOffset(baseDate);
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+export function buildNoonWorklogStartedTimestamp(
+  dateInput?: string | Date | null
+): string {
+  try {
+    const baseDate = parseDateInput(dateInput);
+    if (!baseDate) {
+      return new Date().toISOString();
+    }
+
+    baseDate.setHours(12, 0, 0, 0);
+    return baseDate.toISOString();
+  } catch {
+    return new Date().toISOString();
+  }
+}
+
+export function sumWorklogSeconds(worklogs: JiraWorklog[]): number {
+  return Array.isArray(worklogs)
+    ? worklogs.reduce((total, worklog) => total + worklog.timeSpentSeconds, 0)
+    : 0;
+}

--- a/src/ts/timerFeatureModule/timer.ts
+++ b/src/ts/timerFeatureModule/timer.ts
@@ -3,15 +3,19 @@ import { getErrorMessage } from '../shared/jira-error-handler';
 import '../shared/worklog-suggestions';
 import { getRequiredElement } from '../shared/dom-utils';
 import {
-  autocomplete,
-  bindInfiniteIssuesScroll,
+  loadProjectIssuesIntoAutocomplete,
   setupProjectIssueAutocomplete,
   type ProjectIssueAutocompleteContext,
 } from '../shared/jira-project-issue-autocomplete';
+import {
+  applyStoredTheme,
+  initializeStoredThemeControls,
+} from '../shared/theme-sync';
 import type {
   BackgroundTimerSettings,
   BackgroundWorklogResponse,
   JiraApiClient,
+  JiraIssue,
   TextEntryElement,
   TimerOptions,
   TimerState,
@@ -37,34 +41,8 @@ let seconds = 0;
 let JIRA: JiraApiClient | null = null;
 let _timerSettings: BackgroundTimerSettings | null = null;
 
-(function immediateTheme() {
-  // Synchronously read theme from storage (best effort, may be async, but runs before DOMContentLoaded)
-  if (chrome.storage?.sync?.get) {
-    chrome.storage.sync.get(
-      ['followSystemTheme', 'darkMode'],
-      function (result) {
-        const theme = (result || {}) as {
-          followSystemTheme?: boolean;
-          darkMode?: boolean;
-        };
-        const followSystem = theme.followSystemTheme !== false; // default true
-        const manualDark = theme.darkMode === true;
-        if (followSystem) {
-          const mql = window.matchMedia('(prefers-color-scheme: dark)');
-          setTheme(mql.matches);
-        } else {
-          setTheme(manualDark);
-        }
-      }
-    );
-  }
-  function setTheme(isDark: boolean) {
-    if (isDark) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-    }
-  }
+(function applyInitialTheme() {
+  void applyStoredTheme();
 })();
 
 document.addEventListener('DOMContentLoaded', onDOMContentLoaded);
@@ -181,43 +159,9 @@ async function onDOMContentLoaded(): Promise<void> {
       const themeToggle = document.getElementById(
         'themeToggle'
       ) as HTMLButtonElement | null;
-
-      // Unified theme logic
-      function applyTheme(followSystem: boolean, manualDark: boolean) {
-        if (followSystem) {
-          const mql = window.matchMedia('(prefers-color-scheme: dark)');
-          setTheme(mql.matches);
-          mql.onchange = (e) => setTheme(e.matches);
-          window._systemThemeListener = mql;
-        } else {
-          if (window._systemThemeListener) {
-            window._systemThemeListener.onchange = null;
-            window._systemThemeListener = null;
-          }
-          setTheme(manualDark);
-        }
-      }
-      function setTheme(isDark: boolean) {
-        updateThemeButton(isDark);
-        if (isDark) {
-          document.body.classList.add('dark-mode');
-        } else {
-          document.body.classList.remove('dark-mode');
-        }
-      }
-      // Load settings and apply theme
-      chrome.storage.sync.get(
-        ['followSystemTheme', 'darkMode'],
-        function (result) {
-          const theme = result as {
-            followSystemTheme?: boolean;
-            darkMode?: boolean;
-          };
-          const followSystem = theme.followSystemTheme !== false; // default true
-          const manualDark = theme.darkMode === true;
-          applyTheme(followSystem, manualDark);
-
-          // Initialize worklog suggestions AFTER theme is applied
+      initializeStoredThemeControls({
+        toggle: themeToggle,
+        afterInitialApply: () => {
           const descriptionField = document.getElementById(
             'description'
           ) as TextEntryElement | null;
@@ -227,34 +171,10 @@ async function onDOMContentLoaded(): Promise<void> {
           ) {
             initializeWorklogSuggestions(descriptionField);
           }
-        }
-      );
-      // Theme button disables system-following and sets manual override
-      themeToggle?.addEventListener('click', function () {
-        const isDark = !document.body.classList.contains('dark-mode');
-        updateThemeButton(isDark);
-        setTheme(isDark);
-        chrome.storage.sync.set({ darkMode: isDark, followSystemTheme: false });
+        },
       });
-      // Listen for changes from other tabs/options
+
       chrome.storage.onChanged.addListener(function (changes, namespace) {
-        if (
-          namespace === 'sync' &&
-          ('followSystemTheme' in changes || 'darkMode' in changes)
-        ) {
-          chrome.storage.sync.get(
-            ['followSystemTheme', 'darkMode'],
-            function (result) {
-              const theme = result as {
-                followSystemTheme?: boolean;
-                darkMode?: boolean;
-              };
-              const followSystem = theme.followSystemTheme !== false;
-              const manualDark = theme.darkMode === true;
-              applyTheme(followSystem, manualDark);
-            }
-          );
-        }
         if (
           namespace === 'sync' &&
           ('timerSeconds' in changes ||
@@ -306,9 +226,22 @@ async function init(options: TimerOptions): Promise<void> {
 
 async function setupAutocomplete(JIRA: JiraApiClient): Promise<void> {
   const client = JIRA;
+  const formatIssueRow = (issue: JiraIssue) =>
+    `${issue.key}: ${issue.fields.summary || ''}`;
+  const persistSelectedIssue = (selectedIssue: string) => {
+    const issueKey = selectedIssue.split(':')[0].trim();
+    const issueTitle = selectedIssue
+      .substring(selectedIssue.indexOf(':') + 1)
+      .trim();
+    chrome.storage.sync.set({
+      issueKey: issueKey,
+      issueTitle: issueTitle,
+    });
+  };
+
   await setupProjectIssueAutocomplete(client, {
     getJiraForSuggestions: () => client,
-    formatIssueRow: (i) => `${i.key}: ${i.fields.summary || ''}`,
+    formatIssueRow,
     directIssueHooks: {
       onMismatch: (_inputEl, ctx) => {
         clearIssueStorageFromAutocomplete(ctx);
@@ -332,13 +265,7 @@ async function setupAutocomplete(JIRA: JiraApiClient): Promise<void> {
       selectedProject,
       ctx,
     }) => {
-      const {
-        JIRA: jira,
-        replaceIssueInput,
-        issueInputRef,
-        issueList,
-        projectInput,
-      } = ctx;
+      const { projectInput } = ctx;
       const previousKey =
         projectInput && projectInput.dataset
           ? projectInput.dataset.selectedKey
@@ -348,54 +275,20 @@ async function setupAutocomplete(JIRA: JiraApiClient): Promise<void> {
       if (previousKey && previousKey !== selectedKey) {
         clearIssueStorageFromAutocomplete(ctx);
       }
-      const jql = `project = ${selectedProject.key}`;
-      replaceIssueInput();
-      const page = await jira.getIssuesPage(jql, null, 100);
-      const issueItems = page.data.map(
-        (i) => `${i.key}: ${i.fields.summary || ''}`
-      );
-      autocomplete(
-        issueInputRef.current,
-        issueItems,
-        issueList,
-        (selectedIssue) => {
-          const issueKey = selectedIssue.split(':')[0].trim();
-          const issueTitle = selectedIssue
-            .substring(selectedIssue.indexOf(':') + 1)
-            .trim();
-          chrome.storage.sync.set({
-            issueKey: issueKey,
-            issueTitle: issueTitle,
-          });
-          issueInputRef.current.value = selectedIssue;
-        },
-        {
-          getJiraForSuggestions: () => client,
-        }
-      );
-      bindInfiniteIssuesScroll(
-        issueList,
-        issueItems,
-        jql,
-        jira,
-        issueInputRef.current,
-        (i) => `${i.key}: ${i.fields.summary || ''}`,
-        page.nextCursor
-      );
+      await loadProjectIssuesIntoAutocomplete({
+        ctx,
+        selectedProject,
+        formatIssueRow,
+        getJiraForSuggestions: () => client,
+        onIssueSelected: persistSelectedIssue,
+      });
       chrome.storage.sync.set({
         projectId: selectedKey,
         projectName: selectedProject.name,
       });
     },
     runInitialPreload: async (ctx) => {
-      const {
-        JIRA: jira,
-        projectInput,
-        issueInputRef,
-        projectMap,
-        issueList,
-        replaceIssueInput,
-      } = ctx;
+      const { projectInput, issueInputRef, projectMap } = ctx;
       try {
         const initialVal =
           projectInput && projectInput.value ? projectInput.value : '';
@@ -422,41 +315,13 @@ async function setupAutocomplete(JIRA: JiraApiClient): Promise<void> {
 
         const selectedProject = projectMap.get(initialKey);
         if (!selectedProject) return;
-
-        const jql = `project = ${selectedProject.key}`;
-        replaceIssueInput();
-        const page = await jira.getIssuesPage(jql, null, 100);
-        const issueItems = page.data.map(
-          (i) => `${i.key}: ${i.fields.summary || ''}`
-        );
-        autocomplete(
-          issueInputRef.current,
-          issueItems,
-          issueList,
-          (selectedIssue) => {
-            const issueKey = selectedIssue.split(':')[0].trim();
-            const issueTitle = selectedIssue
-              .substring(selectedIssue.indexOf(':') + 1)
-              .trim();
-            chrome.storage.sync.set({
-              issueKey: issueKey,
-              issueTitle: issueTitle,
-            });
-            issueInputRef.current.value = selectedIssue;
-          },
-          {
-            getJiraForSuggestions: () => client,
-          }
-        );
-        bindInfiniteIssuesScroll(
-          issueList,
-          issueItems,
-          jql,
-          jira,
-          issueInputRef.current,
-          (i) => `${i.key}: ${i.fields.summary || ''}`,
-          page.nextCursor
-        );
+        await loadProjectIssuesIntoAutocomplete({
+          ctx,
+          selectedProject,
+          formatIssueRow,
+          getJiraForSuggestions: () => client,
+          onIssueSelected: persistSelectedIssue,
+        });
       } catch {
         // best-effort init
       }
@@ -942,22 +807,6 @@ function saveTimerState(): void {
 
 function restoreTimerState() {
   loadTimerState(true);
-}
-
-// Function to update the theme button icon
-function updateThemeButton(isDark: boolean) {
-  const themeToggle = document.getElementById(
-    'themeToggle'
-  ) as HTMLButtonElement | null;
-  const iconSpan = themeToggle?.querySelector<HTMLElement>('.icon');
-  if (!themeToggle || !iconSpan) return;
-  if (isDark) {
-    iconSpan.textContent = '☀️';
-    themeToggle.title = 'Switch to light mode';
-  } else {
-    iconSpan.textContent = '🌙';
-    themeToggle.title = 'Switch to dark mode';
-  }
 }
 (window as Window & { displayError?: typeof displayError }).displayError =
   displayError;


### PR DESCRIPTION
## Summary
- centralize theme storage syncing and toggle behavior in `theme-sync` and reuse it across popup, search, timer, CLI, and options
- centralize worklog duration parsing and started timestamp generation in `worklog-time` so logging behavior stays consistent across entry points
- extract shared project issue autocomplete hydration and prevent duplicate infinite-scroll handlers when switching projects

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple entry points (popup/search/timer/CLI/options/content script) and changes shared logic for theme handling plus worklog duration/timestamp generation, which could affect logging behavior or UI theming if edge cases regress.
> 
> **Overview**
> **Centralizes theme behavior across pages.** Adds `shared/theme-sync.ts` and replaces duplicated theme-toggle/system-theme listeners in `popup`, `search`, `timer`, `CLI`, and `options` with `initializeStoredThemeControls` (including a hook to update the options page “follow system” checkbox and a timer-page early `applyStoredTheme` for initial render).
> 
> **Unifies worklog time parsing and started timestamps.** Introduces `shared/worklog-time.ts` (validation + parsing with decimal support, optional weeks, consistent timezone-offset formatting, plus a noon-based timestamp for the content-script popup) and updates `popup`, `search`, `jira-issue-detection`, and `cli` to use it; removes `buildStartedTimestamp` from `shared/jira-api.ts` and `JiraApiClient`.
> 
> **Refactors project/issue autocomplete hydration.** Extracts `loadProjectIssuesIntoAutocomplete` to reuse project issue loading across `search` and `timer`, and updates `bindInfiniteIssuesScroll` to de-register prior scroll handlers to avoid duplicate infinite-scroll listeners when switching projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63ab5a849fed6744403f86992869fb0525e347fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->