### PR TITLE
Page View: timer tab, singleton focus, responsive layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.1 (Apr 14, 2026)
+- Feature: Page view (new tab) is now an experimental feature. Users can now toggle page view (new tab) on and off from the options page. The side panel feature is now deprecated and has been removed.
+- Fix: Live timer badge now updates correctly when the timer is running.
+
 ## 1.5.0 (Apr 12, 2026)
 
 - Development: Migrated extension source to TypeScript (`src/ts`) and HTML templates (`src/html`); bundled JavaScript is emitted to `dist/` with esbuild. Legacy root-level script copies were removed; the manifest now references the built assets under `dist/`.

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.5.0",
   "description": "Log/Track your time in Jira in seconds!",
   "host_permissions": ["<all_urls>"],
-  "permissions": ["storage", "tabs", "windows"],
+  "permissions": ["storage", "tabs"],
   "background": {
     "service_worker": "dist/timerFeatureModule/background.js"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.5.0",
   "description": "Log/Track your time in Jira in seconds!",
   "host_permissions": ["<all_urls>"],
-  "permissions": ["storage", "sidePanel"],
+  "permissions": ["storage", "tabs", "windows"],
   "background": {
     "service_worker": "dist/timerFeatureModule/background.js"
   },
@@ -19,9 +19,6 @@
   "action": {
     "default_icon": "src/icons/jira_logo.png",
     "default_popup": "dist/popup.html"
-  },
-  "side_panel": {
-    "default_path": "dist/popup.html"
   },
   "options_page": "dist/options.html",
   "icons": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Jira Log Time",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Log/Track your time in Jira in seconds!",
   "host_permissions": ["<all_urls>"],
   "permissions": ["storage", "tabs"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-time-tracker-ext",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-time-tracker-ext",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "devDependencies": {
         "@types/chrome": "^0.1.40",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jira-time-tracker-ext",
   "private": true,
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Chrome extension for logging and tracking Jira time.",
   "scripts": {
     "build": "node scripts/build.mjs",

--- a/src/html/cli.html
+++ b/src/html/cli.html
@@ -4,13 +4,25 @@
     <meta charset="UTF-8" />
     <title>Jira Time CLI</title>
     <style>
+      html {
+        height: 100%;
+        width: 100%;
+      }
+
       body {
         width: 750px;
+        margin: 0 auto;
+        min-height: 100vh;
+        box-sizing: border-box;
         font-family: Arial, sans-serif;
-        margin: 0;
         display: flex;
         flex-direction: column;
-        min-height: 100vh;
+      }
+
+      html.page-view-layout body {
+        width: 100%;
+        max-width: 1400px;
+        padding: 0 clamp(12px, 4vw, 32px);
       }
 
       a {

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -696,13 +696,13 @@
               <span class="slider"></span>
             </label>
             <span class="toggle-label"
-              >(Calendar Add-on, Page View, Floating Timer Widget + More Coming
-              Soon!)</span
+              >(Calendar Add-on, page view in a new tab, Floating Timer Widget
+              + More Coming Soon!)</span
             >
           </td>
         </tr>
         <tr id="pageViewRow" style="display: none">
-          <td>Page View</td>
+          <td>Page view (new tab)</td>
           <td>
             <label class="toggle-switch">
               <input type="checkbox" id="pageViewToggle" />

--- a/src/html/options.html
+++ b/src/html/options.html
@@ -4,15 +4,28 @@
     <meta charset="UTF-8" />
     <title>Jira Log Time Settings</title>
     <style>
+      /* Full viewport width so % widths in page view resolve against the window, not 750px. */
+      html {
+        height: 100%;
+        width: 100%;
+      }
+
       body {
         width: 750px;
+        margin: 0 auto;
+        min-height: 100vh;
+        box-sizing: border-box;
         font-family: Arial, sans-serif;
-        margin: 0;
         display: flex;
         flex-direction: column;
-        min-height: 100vh;
         background-color: #fff;
         color: #000;
+      }
+
+      html.page-view-layout body {
+        width: 100%;
+        max-width: 1400px;
+        padding: 0 clamp(12px, 4vw, 32px);
       }
 
       .container {
@@ -683,16 +696,16 @@
               <span class="slider"></span>
             </label>
             <span class="toggle-label"
-              >(Calendar Add-on, Side Panel, Floating Timer Widget + More Coming
+              >(Calendar Add-on, Page View, Floating Timer Widget + More Coming
               Soon!)</span
             >
           </td>
         </tr>
-        <tr id="sidePanelRow" style="display: none">
-          <td>Side Panel</td>
+        <tr id="pageViewRow" style="display: none">
+          <td>Page View</td>
           <td>
             <label class="toggle-switch">
-              <input type="checkbox" id="sidePanelToggle" />
+              <input type="checkbox" id="pageViewToggle" />
               <span class="slider"></span>
             </label>
             <span class="jira-popup-beta-badge">Beta</span>

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -13,10 +13,6 @@
         min-width: 750px;
       }
 
-      html.page-view-layout {
-        min-width: 0;
-      }
-
       /* Toolbar popup: overall width 750px (border-box; no extra px from side padding). */
       body {
         margin: 0;
@@ -113,13 +109,6 @@
         margin-left: 0;
         margin-right: 0;
         table-layout: fixed;
-      }
-
-      /* Only with Experimental + Page View: wider fluid column (see page-view-layout.ts). */
-      html.page-view-layout #jira-log-time-table {
-        width: 100%;
-        margin-left: 0;
-        margin-right: 0;
       }
 
       #jira-log-time-table thead {

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -6,9 +6,34 @@
     <script src="dist/popup.js" defer></script>
     <style type="text/css">
       /* ===== Base/Reset Styles ===== */
+      /* width: 100% so page-view % widths use the popup viewport, not a 750px-tall column. */
+      html {
+        height: 100%;
+        width: 100%;
+        min-width: 750px;
+      }
+
+      html.page-view-layout {
+        min-width: 0;
+      }
+
+      /* Toolbar popup: overall width 750px (border-box; no extra px from side padding). */
       body {
         margin: 0;
         font-family: Arial, sans-serif;
+        width: 750px;
+        box-sizing: border-box;
+        padding: 0;
+        min-height: 100%;
+      }
+
+      /* Experimental + Page View: fluid width up to 1400px (same as full-tab pages). */
+      html.page-view-layout body {
+        width: 100%;
+        max-width: 1400px;
+        margin: 0 auto;
+        box-sizing: border-box;
+        padding: 0 clamp(8px, 2vw, 24px);
       }
 
       table {
@@ -82,9 +107,19 @@
       }
 
       /* ===== Layout & Structure ===== */
+      /* Main table fills the 750px-wide body. */
       #jira-log-time-table {
-        width: 744px;
+        width: 100%;
+        margin-left: 0;
+        margin-right: 0;
         table-layout: fixed;
+      }
+
+      /* Only with Experimental + Page View: wider fluid column (see page-view-layout.ts). */
+      html.page-view-layout #jira-log-time-table {
+        width: 100%;
+        margin-left: 0;
+        margin-right: 0;
       }
 
       #jira-log-time-table thead {

--- a/src/html/search.html
+++ b/src/html/search.html
@@ -4,13 +4,25 @@
     <meta charset="UTF-8" />
     <title>Jira Issue Search</title>
     <style>
+      html {
+        height: 100%;
+        width: 100%;
+      }
+
       body {
         width: 750px;
+        margin: 0 auto;
+        min-height: 100vh;
+        box-sizing: border-box;
         font-family: Arial, sans-serif;
-        margin: 0;
         display: flex;
         flex-direction: column;
-        min-height: 100vh;
+      }
+
+      html.page-view-layout body {
+        width: 100%;
+        max-width: 1400px;
+        padding: 0 clamp(12px, 4vw, 32px);
       }
 
       a {

--- a/src/html/timerFeatureModule/timer.html
+++ b/src/html/timerFeatureModule/timer.html
@@ -10,16 +10,29 @@
       rel="stylesheet"
     />
     <style>
+      html {
+        height: 100%;
+        width: 100%;
+      }
+
       body {
         width: 750px;
+        margin: 0 auto;
+        min-height: 100%;
         font-family: Arial, sans-serif;
-        margin: 0;
         display: flex;
         flex-direction: column;
         padding: 10px;
         padding-bottom: 60px; /* Add space for footer */
         position: relative;
         box-sizing: border-box;
+      }
+
+      html.page-view-layout body {
+        width: 100%;
+        max-width: 1400px;
+        padding: 10px clamp(12px, 4vw, 32px);
+        padding-bottom: 60px;
       }
 
       a {

--- a/src/ts/cli.ts
+++ b/src/ts/cli.ts
@@ -1,6 +1,7 @@
 import './shared/jira-api';
 import { getErrorMessage } from './shared/jira-error-handler';
 import { getRequiredElement } from './shared/dom-utils';
+import { initPageViewLayout } from './shared/page-view-layout';
 import { initializeStoredThemeControls } from './shared/theme-sync';
 import { buildWorklogStartedTimestamp } from './shared/worklog-time';
 import type {
@@ -9,6 +10,8 @@ import type {
   JiraLoginResponse,
   JiraWorklog,
 } from './shared/types';
+
+initPageViewLayout();
 
 interface MeIdentifiers {
   accountId: string | null;

--- a/src/ts/options.ts
+++ b/src/ts/options.ts
@@ -131,7 +131,7 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
       pageViewToggle.checked = false;
       floatingTimerWidgetToggle.checked = false;
       chrome.storage.sync.set({
-        sidePanelEnabled: false,
+        pageViewNewTabEnabled: false,
         floatingTimerWidgetEnabled: false,
       });
     }
@@ -170,7 +170,7 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
   async function saveOptions(): Promise<void> {
     const experimentalFeatures = experimentalFeaturesToggle.checked;
     const issueDetectionEnabled = issueDetectionToggle.checked;
-    const sidePanelEnabled = experimentalFeatures && pageViewToggle.checked;
+    const pageViewNewTabEnabled = experimentalFeatures && pageViewToggle.checked;
     const floatingTimerWidgetEnabled =
       experimentalFeatures && floatingTimerWidgetToggle.checked;
 
@@ -184,7 +184,7 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
       frequentWorklogDescription1: frequentWorklogDescription1Input.value,
       frequentWorklogDescription2: frequentWorklogDescription2Input.value,
       defaultPage: defaultPageSelect.value,
-      sidePanelEnabled,
+      pageViewNewTabEnabled,
       floatingTimerWidgetEnabled,
     });
 
@@ -213,7 +213,7 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
       frequentWorklogDescription2: '',
       defaultPage: 'popup.html',
       followSystemTheme: true,
-      sidePanelEnabled: false,
+      pageViewNewTabEnabled: false,
       floatingTimerWidgetEnabled: false,
       darkMode: false,
     });
@@ -232,7 +232,7 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
       ? 'table-row'
       : 'none';
     pageViewToggle.checked = !!(
-      items.experimentalFeatures && items.sidePanelEnabled
+      items.experimentalFeatures && items.pageViewNewTabEnabled
     );
     floatingTimerWidgetRow.style.display = items.experimentalFeatures
       ? 'table-row'

--- a/src/ts/options.ts
+++ b/src/ts/options.ts
@@ -5,7 +5,10 @@ import type {
 } from './shared/types';
 
 import { getRequiredElement } from './shared/dom-utils';
+import { initPageViewLayout } from './shared/page-view-layout';
 import { initializeStoredThemeControls } from './shared/theme-sync';
+
+initPageViewLayout();
 
 function getRequiredSelector<T extends HTMLElement>(selector: string): T {
   const element = document.querySelector(selector);
@@ -44,9 +47,9 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
   const baseUrlInput = getRequiredElement<HTMLInputElement>('baseUrl');
   const systemThemeToggle =
     getRequiredElement<HTMLInputElement>('systemThemeToggle');
-  const sidePanelToggle =
-    getRequiredElement<HTMLInputElement>('sidePanelToggle');
-  const sidePanelRow = getRequiredElement<HTMLTableRowElement>('sidePanelRow');
+  const pageViewToggle =
+    getRequiredElement<HTMLInputElement>('pageViewToggle');
+  const pageViewRow = getRequiredElement<HTMLTableRowElement>('pageViewRow');
   const floatingTimerWidgetToggle = getRequiredElement<HTMLInputElement>(
     'floatingTimerWidgetToggle'
   );
@@ -121,11 +124,11 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
       .forEach((shape) => {
         shape.style.opacity = isEnabled ? '1' : '0';
       });
-    sidePanelRow.style.display = isEnabled ? 'table-row' : 'none';
+    pageViewRow.style.display = isEnabled ? 'table-row' : 'none';
     floatingTimerWidgetRow.style.display = isEnabled ? 'table-row' : 'none';
 
     if (!isEnabled) {
-      sidePanelToggle.checked = false;
+      pageViewToggle.checked = false;
       floatingTimerWidgetToggle.checked = false;
       chrome.storage.sync.set({
         sidePanelEnabled: false,
@@ -167,7 +170,7 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
   async function saveOptions(): Promise<void> {
     const experimentalFeatures = experimentalFeaturesToggle.checked;
     const issueDetectionEnabled = issueDetectionToggle.checked;
-    const sidePanelEnabled = experimentalFeatures && sidePanelToggle.checked;
+    const sidePanelEnabled = experimentalFeatures && pageViewToggle.checked;
     const floatingTimerWidgetEnabled =
       experimentalFeatures && floatingTimerWidgetToggle.checked;
 
@@ -225,10 +228,10 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
     frequentWorklogDescription2Input.value = items.frequentWorklogDescription2;
     defaultPageSelect.value = items.defaultPage;
     systemThemeToggle.checked = items.followSystemTheme;
-    sidePanelRow.style.display = items.experimentalFeatures
+    pageViewRow.style.display = items.experimentalFeatures
       ? 'table-row'
       : 'none';
-    sidePanelToggle.checked = !!(
+    pageViewToggle.checked = !!(
       items.experimentalFeatures && items.sidePanelEnabled
     );
     floatingTimerWidgetRow.style.display = items.experimentalFeatures

--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -1,6 +1,7 @@
 import './shared/jira-api';
 import { getErrorMessage } from './shared/jira-error-handler';
 import './shared/worklog-suggestions';
+import { initPageViewLayout } from './shared/page-view-layout';
 import { initializeStoredThemeControls } from './shared/theme-sync';
 import {
   buildWorklogStartedTimestamp,
@@ -17,6 +18,8 @@ import type {
   PopupColumnVisibility,
   PopupOptions,
 } from './shared/types';
+
+initPageViewLayout();
 
 type CachedIssuesResponse = {
   data: JiraIssuesResponse;

--- a/src/ts/search.ts
+++ b/src/ts/search.ts
@@ -6,6 +6,7 @@ import {
   loadProjectIssuesIntoAutocomplete,
   setupProjectIssueAutocomplete,
 } from './shared/jira-project-issue-autocomplete';
+import { initPageViewLayout } from './shared/page-view-layout';
 import { initializeStoredThemeControls } from './shared/theme-sync';
 import {
   buildWorklogStartedTimestamp,
@@ -18,6 +19,8 @@ import type {
   SearchOptions,
   TextEntryElement,
 } from './shared/types';
+
+initPageViewLayout();
 
 document.addEventListener('DOMContentLoaded', function () {
   const themeToggleElement = document.getElementById(

--- a/src/ts/shared/page-view-layout.ts
+++ b/src/ts/shared/page-view-layout.ts
@@ -1,0 +1,34 @@
+/**
+ * Fluid centered layout when Experimental + Page View are on; otherwise fixed
+ * width (750px body / table). Uses `sidePanelEnabled` storage key.
+ * Applies to full-tab pages and to `popup.html` when opened (e.g. menu).
+ */
+function readPageViewLayoutEnabled(items: Record<string, unknown>): boolean {
+  return (
+    items.experimentalFeatures === true && items.sidePanelEnabled === true
+  );
+}
+
+function applyPageViewLayoutClass(enabled: boolean): void {
+  document.documentElement.classList.toggle('page-view-layout', enabled);
+}
+
+export function initPageViewLayout(): void {
+  chrome.storage.sync.get(
+    { sidePanelEnabled: false, experimentalFeatures: false },
+    (items) => {
+      applyPageViewLayoutClass(readPageViewLayoutEnabled(items));
+    }
+  );
+
+  chrome.storage.onChanged.addListener((changes, namespace) => {
+    if (namespace !== 'sync') return;
+    if (!changes.sidePanelEnabled && !changes.experimentalFeatures) return;
+    chrome.storage.sync.get(
+      { sidePanelEnabled: false, experimentalFeatures: false },
+      (items) => {
+        applyPageViewLayoutClass(readPageViewLayoutEnabled(items));
+      }
+    );
+  });
+}

--- a/src/ts/shared/page-view-layout.ts
+++ b/src/ts/shared/page-view-layout.ts
@@ -1,11 +1,11 @@
 /**
- * Fluid centered layout when Experimental + Page View are on; otherwise fixed
- * width (750px body / table). Uses `sidePanelEnabled` storage key.
+ * Fluid centered layout when Experimental + Page View (new tab) are on; otherwise fixed
+ * width (750px body / table). Uses `pageViewNewTabEnabled` in sync storage.
  * Applies to full-tab pages and to `popup.html` when opened (e.g. menu).
  */
 function readPageViewLayoutEnabled(items: Record<string, unknown>): boolean {
   return (
-    items.experimentalFeatures === true && items.sidePanelEnabled === true
+    items.experimentalFeatures === true && items.pageViewNewTabEnabled === true
   );
 }
 
@@ -15,7 +15,7 @@ function applyPageViewLayoutClass(enabled: boolean): void {
 
 export function initPageViewLayout(): void {
   chrome.storage.sync.get(
-    { sidePanelEnabled: false, experimentalFeatures: false },
+    { pageViewNewTabEnabled: false, experimentalFeatures: false },
     (items) => {
       applyPageViewLayoutClass(readPageViewLayoutEnabled(items));
     }
@@ -23,9 +23,9 @@ export function initPageViewLayout(): void {
 
   chrome.storage.onChanged.addListener((changes, namespace) => {
     if (namespace !== 'sync') return;
-    if (!changes.sidePanelEnabled && !changes.experimentalFeatures) return;
+    if (!changes.pageViewNewTabEnabled && !changes.experimentalFeatures) return;
     chrome.storage.sync.get(
-      { sidePanelEnabled: false, experimentalFeatures: false },
+      { pageViewNewTabEnabled: false, experimentalFeatures: false },
       (items) => {
         applyPageViewLayoutClass(readPageViewLayoutEnabled(items));
       }

--- a/src/ts/shared/types.ts
+++ b/src/ts/shared/types.ts
@@ -175,14 +175,15 @@ export interface ExtensionSettings {
   floatingTimerWidgetEnabled?: boolean;
   followSystemTheme?: boolean;
   darkMode?: boolean;
-  sidePanelEnabled?: boolean;
+  /** Open full timer page in a new tab when clicking the toolbar icon (vs popup). */
+  pageViewNewTabEnabled?: boolean;
 }
 
 export interface OptionsPageSettings extends BaseExtensionOptions {
   issueDetectionEnabled: boolean;
   defaultPage: string;
   followSystemTheme: boolean;
-  sidePanelEnabled: boolean;
+  pageViewNewTabEnabled: boolean;
   floatingTimerWidgetEnabled: boolean;
 }
 

--- a/src/ts/timerFeatureModule/background.ts
+++ b/src/ts/timerFeatureModule/background.ts
@@ -89,20 +89,19 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 });
 
-/** Timer full-page URL (singleton: focus existing tab instead of opening duplicates). */
 function getTimerPageUrl(): string {
   return chrome.runtime.getURL(TIMER_PAGE_PATH);
 }
 
+function getExtensionTabsUrlPattern(): string {
+  return `${new URL(chrome.runtime.getURL(POPUP_PATH)).origin}/*`;
+}
+
 async function focusOrOpenTimerTab(refTab?: chrome.tabs.Tab): Promise<void> {
   const timerUrl = getTimerPageUrl();
-  const urlPrefix = timerUrl.split(/[?#]/)[0] ?? timerUrl;
 
   try {
-    const allTabs = await chrome.tabs.query({});
-    const matches = allTabs.filter(
-      (t) => typeof t.url === 'string' && t.url.startsWith(urlPrefix)
-    );
+    const matches = await chrome.tabs.query({ url: getExtensionTabsUrlPattern() });
     if (matches.length > 0) {
       const existing = matches.sort(
         (a, b) => (b.lastAccessed ?? 0) - (a.lastAccessed ?? 0)

--- a/src/ts/timerFeatureModule/background.ts
+++ b/src/ts/timerFeatureModule/background.ts
@@ -190,7 +190,7 @@ async function handleWorklogRequest(
 
 function clearBadgeInterval(): void {
   if (badgeUpdateInterval !== null) {
-    window.clearInterval(badgeUpdateInterval);
+    clearInterval(badgeUpdateInterval);
     badgeUpdateInterval = null;
   }
 }
@@ -200,7 +200,7 @@ function startBadgeUpdate(seconds: number): void {
   isRunning = true;
   updateBadge(currentSeconds, isRunning);
   clearBadgeInterval();
-  badgeUpdateInterval = window.setInterval(() => {
+  badgeUpdateInterval = setInterval(() => {
     currentSeconds += 1;
     updateBadge(currentSeconds, isRunning);
   }, 1000);

--- a/src/ts/timerFeatureModule/background.ts
+++ b/src/ts/timerFeatureModule/background.ts
@@ -115,8 +115,6 @@ async function focusOrOpenTimerTab(refTab?: chrome.tabs.Tab): Promise<void> {
     }
   } catch (error) {
     console.error('focusOrOpenTimerTab:', error);
-    // Unlikey case, but if we can't focus or open the timer tab due the window closing between the two awaits, just return
-    return;
   }
 
   openUrlInTab(timerUrl, refTab);

--- a/src/ts/timerFeatureModule/background.ts
+++ b/src/ts/timerFeatureModule/background.ts
@@ -115,6 +115,8 @@ async function focusOrOpenTimerTab(refTab?: chrome.tabs.Tab): Promise<void> {
     }
   } catch (error) {
     console.error('focusOrOpenTimerTab:', error);
+    // Unlikey case, but if we can't focus or open the timer tab due the window closing between the two awaits, just return
+    return;
   }
 
   openUrlInTab(timerUrl, refTab);

--- a/src/ts/timerFeatureModule/background.ts
+++ b/src/ts/timerFeatureModule/background.ts
@@ -4,13 +4,15 @@ import type {
   BackgroundWorklogResponse,
 } from '../shared/types';
 
+const POPUP_PATH = 'dist/popup.html';
+const TIMER_PAGE_PATH = 'dist/timerFeatureModule/timer.html';
+
 type BackgroundMessage =
   | { action: 'startTimer'; seconds: number }
   | { action: 'stopTimer' }
   | { action: 'resetTimer' }
   | { action: 'updateBadge'; seconds: number; isRunning: boolean }
   | { action: 'syncTime'; seconds: number; isRunning: boolean }
-  | { action: 'openSidePanel' }
   | { action: 'openUrl'; url: string }
   | BackgroundWorklogRequest;
 
@@ -18,28 +20,38 @@ let badgeUpdateInterval: number | null = null;
 let currentSeconds = 0;
 let isRunning = false;
 
-async function initSidePanelBehavior(): Promise<void> {
+async function applyToolbarActionMode(openPageView: boolean): Promise<void> {
+  try {
+    if (openPageView) {
+      await chrome.action.setPopup({ popup: '' });
+    } else {
+      await chrome.action.setPopup({ popup: POPUP_PATH });
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function initToolbarActionFromStorage(): Promise<void> {
   const items = await new Promise<{ sidePanelEnabled: boolean }>((resolve) => {
     chrome.storage.sync.get({ sidePanelEnabled: false }, (result) => {
       resolve(result as { sidePanelEnabled: boolean });
     });
   });
 
-  void chrome.sidePanel
-    .setPanelBehavior({ openPanelOnActionClick: items.sidePanelEnabled })
-    .catch((error) => console.error(error));
+  await applyToolbarActionMode(items.sidePanelEnabled);
 }
 
-void initSidePanelBehavior();
+void initToolbarActionFromStorage();
 
 chrome.storage.onChanged.addListener((changes, namespace) => {
   if (namespace === 'sync' && changes.sidePanelEnabled) {
-    void chrome.sidePanel
-      .setPanelBehavior({
-        openPanelOnActionClick: changes.sidePanelEnabled.newValue === true,
-      })
-      .catch((error) => console.error(error));
+    void applyToolbarActionMode(changes.sidePanelEnabled.newValue === true);
   }
+});
+
+chrome.action.onClicked.addListener((tab) => {
+  void focusOrOpenTimerTab(tab);
 });
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -61,13 +73,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     case 'syncTime':
       syncTime(message.seconds, message.isRunning);
       return false;
-    case 'openSidePanel':
-      if (sender.tab?.windowId) {
-        void chrome.sidePanel.open({ windowId: sender.tab.windowId });
-      }
-      return false;
     case 'openUrl':
-      openUrlInTab(message.url, sender);
+      openUrlInTab(message.url, sender.tab);
       return false;
     case 'logWorklog':
       void handleWorklogRequest(
@@ -80,17 +87,47 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   }
 });
 
-function openUrlInTab(
-  url: string,
-  sender?: chrome.runtime.MessageSender
-): void {
+/** Timer full-page URL (singleton: focus existing tab instead of opening duplicates). */
+function getTimerPageUrl(): string {
+  return chrome.runtime.getURL(TIMER_PAGE_PATH);
+}
+
+async function focusOrOpenTimerTab(refTab?: chrome.tabs.Tab): Promise<void> {
+  const timerUrl = getTimerPageUrl();
+  const urlPrefix = timerUrl.split(/[?#]/)[0] ?? timerUrl;
+
+  try {
+    const allTabs = await chrome.tabs.query({});
+    const matches = allTabs.filter(
+      (t) => typeof t.url === 'string' && t.url.startsWith(urlPrefix)
+    );
+    if (matches.length > 0) {
+      const existing = matches.sort(
+        (a, b) => (b.lastAccessed ?? 0) - (a.lastAccessed ?? 0)
+      )[0];
+      if (existing?.id != null) {
+        await chrome.tabs.update(existing.id, { active: true });
+        if (existing.windowId != null) {
+          await chrome.windows.update(existing.windowId, { focused: true });
+        }
+        return;
+      }
+    }
+  } catch (error) {
+    console.error('focusOrOpenTimerTab:', error);
+  }
+
+  openUrlInTab(timerUrl, refTab);
+}
+
+function openUrlInTab(url: string, refTab?: chrome.tabs.Tab): void {
   if (!url) return;
 
   const createProperties: chrome.tabs.CreateProperties = { url };
-  if (sender?.tab?.windowId) {
-    createProperties.windowId = sender.tab.windowId;
-    if (typeof sender.tab.index === 'number') {
-      createProperties.index = sender.tab.index + 1;
+  if (refTab?.windowId != null) {
+    createProperties.windowId = refTab.windowId;
+    if (typeof refTab.index === 'number') {
+      createProperties.index = refTab.index + 1;
     }
   }
 

--- a/src/ts/timerFeatureModule/background.ts
+++ b/src/ts/timerFeatureModule/background.ts
@@ -20,9 +20,9 @@ let badgeUpdateInterval: number | null = null;
 let currentSeconds = 0;
 let isRunning = false;
 
-async function applyToolbarActionMode(openPageView: boolean): Promise<void> {
+async function applyToolbarActionMode(openTimerPageInNewTab: boolean): Promise<void> {
   try {
-    if (openPageView) {
+    if (openTimerPageInNewTab) {
       await chrome.action.setPopup({ popup: '' });
     } else {
       await chrome.action.setPopup({ popup: POPUP_PATH });
@@ -33,20 +33,22 @@ async function applyToolbarActionMode(openPageView: boolean): Promise<void> {
 }
 
 async function initToolbarActionFromStorage(): Promise<void> {
-  const items = await new Promise<{ sidePanelEnabled: boolean }>((resolve) => {
-    chrome.storage.sync.get({ sidePanelEnabled: false }, (result) => {
-      resolve(result as { sidePanelEnabled: boolean });
-    });
-  });
+  const items = await new Promise<{ pageViewNewTabEnabled: boolean }>(
+    (resolve) => {
+      chrome.storage.sync.get({ pageViewNewTabEnabled: false }, (result) => {
+        resolve(result as { pageViewNewTabEnabled: boolean });
+      });
+    }
+  );
 
-  await applyToolbarActionMode(items.sidePanelEnabled);
+  await applyToolbarActionMode(items.pageViewNewTabEnabled === true);
 }
 
 void initToolbarActionFromStorage();
 
 chrome.storage.onChanged.addListener((changes, namespace) => {
-  if (namespace === 'sync' && changes.sidePanelEnabled) {
-    void applyToolbarActionMode(changes.sidePanelEnabled.newValue === true);
+  if (namespace === 'sync' && changes.pageViewNewTabEnabled) {
+    void applyToolbarActionMode(changes.pageViewNewTabEnabled.newValue === true);
   }
 });
 

--- a/src/ts/timerFeatureModule/timer.ts
+++ b/src/ts/timerFeatureModule/timer.ts
@@ -7,6 +7,7 @@ import {
   setupProjectIssueAutocomplete,
   type ProjectIssueAutocompleteContext,
 } from '../shared/jira-project-issue-autocomplete';
+import { initPageViewLayout } from '../shared/page-view-layout';
 import {
   applyStoredTheme,
   initializeStoredThemeControls,
@@ -20,6 +21,8 @@ import type {
   TimerOptions,
   TimerState,
 } from '../shared/types';
+
+initPageViewLayout();
 
 type CommentContainerVisibilityDetail = { shown: boolean };
 


### PR DESCRIPTION
## Summary
- Replaces the Chrome side panel with **Page View**: when Experimental + Page View are on, the toolbar opens the full **timer** page in a tab instead of the popup (manifest drops `sidePanel`; adds `tabs` and `windows`).
- **Singleton behavior**: `focusOrOpenTimerTab` finds an existing timer tab, activates it, and focuses its window (`chrome.windows.update`); otherwise creates a tab.
- **Layout**: `page-view-layout.ts` toggles `html.page-view-layout` from sync storage; full-tab pages (and optional popup fluid mode) use up to **1400px** width when Page View is on; default remains **750px**. Toolbar popup is **750px** overall.
- Options: label **Page View** (storage key `sidePanelEnabled` unchanged).

## Testing
- [x] Toggle Page View, toolbar opens/focuses timer tab without duplicate tabs
- [x] Timer in another window comes to front when clicking the extension icon
- [x] With Page View off, toolbar shows the usual popup at 750px

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the extension’s primary action-click behavior (popup vs opening/focusing a tab) and updates Chrome permissions (`tabs`), which could affect navigation and user expectations if misconfigured.
> 
> **Overview**
> Adds an *experimental* **Page View (new tab)** mode that replaces the removed Side Panel: when enabled, clicking the toolbar icon opens (or focuses) a single existing timer tab instead of showing the popup.
> 
> Implements shared `initPageViewLayout()` to toggle a `html.page-view-layout` class from sync storage and updates multiple pages’ CSS to use a fluid, centered layout up to 1400px while keeping the default 750px popup layout.
> 
> Updates the background service worker to manage toolbar popup vs click handling via `chrome.action.setPopup`, add singleton tab focus logic (`focusOrOpenTimerTab`), and fixes live timer badge updates by using `setInterval`/`clearInterval` directly. Also bumps version to `1.5.1` and updates manifest permissions from `sidePanel` to `tabs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b41a23c3403df27f1b1e69cc856bfe6ca7720016. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->