### PR TITLE
feat: timetable sort setting

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -6,7 +6,7 @@
     <script src="dist/popup.js" defer></script>
     <style type="text/css">
       /* ===== Base/Reset Styles ===== */
-      /* width: 100% so page-view % widths use the popup viewport, not a 750px-tall column. */
+      /* width: 100% so page-view % widths use the popup viewport, not a fixed-width column. */
       html {
         height: 100%;
         width: 100%;
@@ -103,7 +103,7 @@
       }
 
       /* ===== Layout & Structure ===== */
-      /* Main table fills the 750px-wide body. */
+      /* Main table fills the popup body. */
       #jira-log-time-table {
         width: 100%;
         margin-left: 0;
@@ -1041,7 +1041,8 @@
         background: #fff;
         border-radius: 8px;
         box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
-        width: 360px;
+        width: 460px;
+        max-width: calc(100vw - 32px);
         max-height: 80vh;
         overflow-y: auto;
         font-size: 12px;
@@ -1093,6 +1094,20 @@
         min-height: 48px;
       }
       .gear-section textarea:focus {
+        outline: none;
+        border-color: #0052cc;
+      }
+      .gear-section select {
+        width: 100%;
+        box-sizing: border-box;
+        font-size: 11px;
+        padding: 6px;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        background: #fff;
+        color: #333;
+      }
+      .gear-section select:focus {
         outline: none;
         border-color: #0052cc;
       }
@@ -1191,6 +1206,14 @@
         border-color: #333;
       }
       body.dark-mode .gear-section textarea:focus {
+        border-color: #4690dd;
+      }
+      body.dark-mode .gear-section select {
+        background: #141414;
+        color: #e0e0e0;
+        border-color: #333;
+      }
+      body.dark-mode .gear-section select:focus {
         border-color: #4690dd;
       }
       body.dark-mode #gear-column-order li {
@@ -1329,6 +1352,20 @@
               >.
             </p>
             <textarea id="gear-jql"></textarea>
+          </div>
+          <div class="gear-section">
+            <div class="gear-section-title">Sort</div>
+            <select
+              id="gear-time-table-sort"
+              aria-label="Sort timetable tickets"
+            >
+              <option value="default">Default</option>
+              <option value="dateNewest">Recently updated first</option>
+              <option value="dateOldest">Oldest updated first</option>
+              <option value="totalDesc">Most logged time first</option>
+              <option value="totalAsc">Least logged time first</option>
+              <option value="priority">Highest priority first</option>
+            </select>
           </div>
           <div class="gear-section">
             <div class="gear-section-title">Columns</div>

--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -1189,11 +1189,7 @@ const cellBuilders: Record<ColumnId, CellBuilder> = {
 
   total(issue, options) {
     const id = issue.key;
-    const worklogs = issue.fields.worklog?.worklogs || [];
-    const totalSecs = worklogs.reduce(
-      (acc, wl) => acc + wl.timeSpentSeconds,
-      0
-    );
+    const totalSecs = getIssueTotalSeconds(issue);
     const totalTime = (totalSecs / 3600).toFixed(1) + ' hrs';
     const td = buildHTML('td', null, {
       class: 'issue-total-time',
@@ -1209,6 +1205,12 @@ const cellBuilders: Record<ColumnId, CellBuilder> = {
     });
     td.appendChild(loader);
     td.appendChild(totalTimeDiv);
+
+    if (typeof issue.fields.timespent === 'number') {
+      loader.style.display = 'none';
+      return td;
+    }
+
     (async () => {
       try {
         const JIRA = await getSharedJira(options);

--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -337,21 +337,25 @@ function initGearPanel(options: PopupOptions) {
       }
     } else {
       // Just redraw table with new column settings
-      redrawCurrentTable(options);
+      await redrawCurrentTable(options);
     }
     insertFrequentWorklogDescription(options);
   });
 }
 
-function redrawCurrentTable(options: PopupOptions) {
+async function redrawCurrentTable(options: PopupOptions) {
   const cacheKey = getIssuesCacheKey(options);
-  chrome.storage.local.get([cacheKey], (items) => {
-    const cached = items[cacheKey] as CachedIssuesResponse | undefined;
-    if (cached && cached.data) {
-      void onFetchSuccess(cached.data, options);
-      insertFrequentWorklogDescription(options);
+  const cached = await new Promise<CachedIssuesResponse | undefined>(
+    (resolve) => {
+      chrome.storage.local.get([cacheKey], (items) =>
+        resolve(items[cacheKey] as CachedIssuesResponse | undefined)
+      );
     }
-  });
+  );
+
+  if (cached && cached.data) {
+    await onFetchSuccess(cached.data, options);
+  }
 }
 
 // Drag-and-drop column order in gear panel (with inline visibility toggles)

--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -674,50 +674,13 @@ async function init(options: PopupOptions) {
   }
 }
 
-async function onFetchSuccess(
+function onFetchSuccess(
   issuesResponse: JiraIssuesResponse,
   options: PopupOptions
 ) {
   clearMessages();
   console.log('Fetched issues:', issuesResponse);
-  const hydratedResponse = isTotalSort(options.timeTableSort)
-    ? await hydrateIssueWorklogsForTotalSort(issuesResponse, options)
-    : issuesResponse;
-  drawIssuesTable(hydratedResponse, options);
-}
-
-function isTotalSort(sortMode: TimeTableSort) {
-  return sortMode === 'totalDesc' || sortMode === 'totalAsc';
-}
-
-async function hydrateIssueWorklogsForTotalSort(
-  issuesResponse: JiraIssuesResponse,
-  options: PopupOptions
-): Promise<JiraIssuesResponse> {
-  try {
-    const JIRA = await getSharedJira(options);
-    const data = await Promise.all(
-      (issuesResponse.data || []).map(async (issue) => {
-        try {
-          const worklog = await JIRA.getIssueWorklog(issue.key);
-          return {
-            ...issue,
-            fields: {
-              ...issue.fields,
-              worklog,
-            },
-          };
-        } catch (err) {
-          console.warn(`Failed to fetch worklogs for ${issue.key}:`, err);
-          return issue;
-        }
-      })
-    );
-    return { ...issuesResponse, data };
-  } catch (err) {
-    console.warn('Failed to prepare worklog totals for sorting:', err);
-    return issuesResponse;
-  }
+  drawIssuesTable(issuesResponse, options);
 }
 
 function getWorklog(issueId: string, JIRA: JiraApiClient) {
@@ -1027,15 +990,16 @@ function getIssueDateMs(issue: JiraIssue) {
 }
 
 function getIssueTotalSeconds(issue: JiraIssue) {
+  if (typeof issue.fields.timespent === 'number') {
+    return issue.fields.timespent;
+  }
+
   return sumWorklogSeconds(issue.fields.worklog?.worklogs || []);
 }
 
 function getIssuePriorityRank(issue: JiraIssue) {
   const priorityName = (issue.fields.priority?.name || '').toLowerCase();
   if (priorityName in PRIORITY_RANKS) return PRIORITY_RANKS[priorityName];
-
-  const numericId = Number(issue.fields.priority?.id);
-  if (Number.isFinite(numericId)) return -numericId;
 
   return 0;
 }

--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -17,6 +17,7 @@ import type {
   JiraWorklog,
   PopupColumnVisibility,
   PopupOptions,
+  TimeTableSort,
 } from './shared/types';
 
 initPageViewLayout();
@@ -54,6 +55,20 @@ const DEFAULT_TIME_TABLE_COLUMNS = {
   showAssignee: false,
   showTotal: true,
   showComment: true,
+};
+const DEFAULT_TIME_TABLE_SORT: TimeTableSort = 'default';
+const PRIORITY_RANKS: Record<string, number> = {
+  highest: 5,
+  blocker: 5,
+  critical: 5,
+  high: 4,
+  major: 4,
+  medium: 3,
+  normal: 3,
+  minor: 2,
+  low: 2,
+  lowest: 1,
+  trivial: 1,
 };
 
 type ColumnId = keyof typeof COLUMN_DEFS;
@@ -144,6 +159,7 @@ async function onDOMContentLoaded() {
       experimentalFeatures: false,
       timeTableColumns: DEFAULT_TIME_TABLE_COLUMNS,
       timeTableColumnOrder: DEFAULT_COLUMN_ORDER,
+      timeTableSort: DEFAULT_TIME_TABLE_SORT,
     },
     async (storedOptions) => {
       const options = storedOptions as unknown as PopupOptions;
@@ -156,6 +172,7 @@ async function onDOMContentLoaded() {
       options.timeTableColumnOrder = normalizeColumnOrder(
         options.timeTableColumnOrder
       );
+      options.timeTableSort = normalizeTimeTableSort(options.timeTableSort);
 
       const urlParams = new URLSearchParams(window.location.search);
       const isNavigatingBack = urlParams.get('source') === 'navigation';
@@ -182,6 +199,21 @@ async function onDOMContentLoaded() {
   );
 }
 
+function normalizeTimeTableSort(sort: unknown): TimeTableSort {
+  return isTimeTableSort(sort) ? sort : DEFAULT_TIME_TABLE_SORT;
+}
+
+function isTimeTableSort(sort: unknown): sort is TimeTableSort {
+  return (
+    sort === 'default' ||
+    sort === 'dateNewest' ||
+    sort === 'dateOldest' ||
+    sort === 'totalDesc' ||
+    sort === 'totalAsc' ||
+    sort === 'priority'
+  );
+}
+
 function filterExpiredStars(
   starredIssues: Record<string, number>,
   days: number
@@ -205,6 +237,11 @@ function syncGearPanelState(options: PopupOptions) {
     'gear-jql'
   ) as HTMLTextAreaElement | null;
   if (jqlTextarea) jqlTextarea.value = options.jql || DEFAULT_JQL;
+
+  const sortSelect = document.getElementById(
+    'gear-time-table-sort'
+  ) as HTMLSelectElement | null;
+  if (sortSelect) sortSelect.value = options.timeTableSort;
 
   renderGearColumnOrder(
     options.timeTableColumnOrder.filter(isColumnId),
@@ -245,6 +282,9 @@ function initGearPanel(options: PopupOptions) {
   const jqlTextarea = document.getElementById(
     'gear-jql'
   ) as HTMLTextAreaElement;
+  const sortSelect = document.getElementById(
+    'gear-time-table-sort'
+  ) as HTMLSelectElement;
 
   syncGearPanelState(options);
 
@@ -261,16 +301,19 @@ function initGearPanel(options: PopupOptions) {
     const newJql = jqlTextarea.value.trim() || DEFAULT_JQL;
     const newCols = readGearColumnVisibility();
     const newOrder = readGearColumnOrder();
+    const newSort = normalizeTimeTableSort(sortSelect.value);
     const jqlChanged = newJql !== options.jql;
 
     options.jql = newJql;
     options.timeTableColumns = newCols;
     options.timeTableColumnOrder = newOrder;
+    options.timeTableSort = newSort;
 
     chrome.storage.sync.set({
       jql: newJql,
       timeTableColumns: newCols,
       timeTableColumnOrder: newOrder,
+      timeTableSort: newSort,
     });
 
     closeGearModal();
@@ -284,7 +327,7 @@ function initGearPanel(options: PopupOptions) {
         chrome.storage.local.set({
           [cacheKey]: { data: issuesResponse, ts: Date.now() },
         });
-        onFetchSuccess(issuesResponse, options);
+        await onFetchSuccess(issuesResponse, options);
       } catch (err) {
         await handleTimeTableFetchError(
           err,
@@ -305,7 +348,7 @@ function redrawCurrentTable(options: PopupOptions) {
   chrome.storage.local.get([cacheKey], (items) => {
     const cached = items[cacheKey] as CachedIssuesResponse | undefined;
     if (cached && cached.data) {
-      onFetchSuccess(cached.data, options);
+      void onFetchSuccess(cached.data, options);
       insertFrequentWorklogDescription(options);
     }
   });
@@ -577,7 +620,7 @@ async function init(options: PopupOptions) {
       if (cached && cached.data && Date.now() - cached.ts < 5 * 60 * 1000) {
         // Show cached data immediately (if less than 5 min old)
         console.log('Showing cached issues');
-        onFetchSuccess(cached.data, options);
+        await onFetchSuccess(cached.data, options);
         showedCached = true;
       }
     } catch (e) {
@@ -603,7 +646,7 @@ async function init(options: PopupOptions) {
       }
 
       // Update UI with fresh data
-      onFetchSuccess(issuesResponse, options);
+      await onFetchSuccess(issuesResponse, options);
     } catch (error) {
       console.error('Error fetching issues:', error);
       await handleTimeTableFetchError(
@@ -627,13 +670,50 @@ async function init(options: PopupOptions) {
   }
 }
 
-function onFetchSuccess(
+async function onFetchSuccess(
   issuesResponse: JiraIssuesResponse,
   options: PopupOptions
 ) {
   clearMessages();
   console.log('Fetched issues:', issuesResponse);
-  drawIssuesTable(issuesResponse, options); // Pass options to the function
+  const hydratedResponse = isTotalSort(options.timeTableSort)
+    ? await hydrateIssueWorklogsForTotalSort(issuesResponse, options)
+    : issuesResponse;
+  drawIssuesTable(hydratedResponse, options);
+}
+
+function isTotalSort(sortMode: TimeTableSort) {
+  return sortMode === 'totalDesc' || sortMode === 'totalAsc';
+}
+
+async function hydrateIssueWorklogsForTotalSort(
+  issuesResponse: JiraIssuesResponse,
+  options: PopupOptions
+): Promise<JiraIssuesResponse> {
+  try {
+    const JIRA = await getSharedJira(options);
+    const data = await Promise.all(
+      (issuesResponse.data || []).map(async (issue) => {
+        try {
+          const worklog = await JIRA.getIssueWorklog(issue.key);
+          return {
+            ...issue,
+            fields: {
+              ...issue.fields,
+              worklog,
+            },
+          };
+        } catch (err) {
+          console.warn(`Failed to fetch worklogs for ${issue.key}:`, err);
+          return issue;
+        }
+      })
+    );
+    return { ...issuesResponse, data };
+  } catch (err) {
+    console.warn('Failed to prepare worklog totals for sorting:', err);
+    return issuesResponse;
+  }
 }
 
 function getWorklog(issueId: string, JIRA: JiraApiClient) {
@@ -730,9 +810,7 @@ async function logTimeClick(evt: Event) {
   }
 
   if (!isValidWorklogDuration(timeInput.value, { allowWeeks: true })) {
-    displayError(
-      getWorklogDurationValidationMessage({ allowWeeks: true })
-    );
+    displayError(getWorklogDurationValidationMessage({ allowWeeks: true }));
     return;
   }
 
@@ -878,7 +956,11 @@ function drawIssuesTable(
 
   const newTbody = document.createElement('tbody');
   const issues = issuesResponse.data || [];
-  const sortedIssues = sortByStar(issues, options.starredIssues);
+  const sortedIssues = sortIssues(
+    issues,
+    options.starredIssues,
+    options.timeTableSort
+  );
 
   sortedIssues.forEach((issue) => {
     const row = generateLogTableRow(issue, options, visibleCols);
@@ -896,18 +978,62 @@ function drawIssuesTable(
     });
 }
 
-// ⭐️ utility function that sorts starred issues to top
-function sortByStar(
+function sortIssues(
   issues: JiraIssue[],
-  starredIssues: Record<string, number>
+  starredIssues: Record<string, number>,
+  sortMode: TimeTableSort
 ) {
-  // Return a new array sorted by whether the item is starred
-  return issues.slice().sort((a, b) => {
-    const aStar = starredIssues[a.key] ? 1 : 0;
-    const bStar = starredIssues[b.key] ? 1 : 0;
-    // Sort descending so starred=1 goes first
-    return bStar - aStar;
-  });
+  return issues
+    .map((issue, index) => ({ issue, index }))
+    .sort((a, b) => {
+      const starCompare =
+        Number(!!starredIssues[b.issue.key]) -
+        Number(!!starredIssues[a.issue.key]);
+      if (starCompare !== 0) return starCompare;
+
+      const sortCompare = compareIssues(a.issue, b.issue, sortMode);
+      if (sortCompare !== 0) return sortCompare;
+
+      return a.index - b.index;
+    })
+    .map(({ issue }) => issue);
+}
+
+function compareIssues(a: JiraIssue, b: JiraIssue, sortMode: TimeTableSort) {
+  switch (sortMode) {
+    case 'dateNewest':
+      return getIssueDateMs(b) - getIssueDateMs(a);
+    case 'dateOldest':
+      return getIssueDateMs(a) - getIssueDateMs(b);
+    case 'totalDesc':
+      return getIssueTotalSeconds(b) - getIssueTotalSeconds(a);
+    case 'totalAsc':
+      return getIssueTotalSeconds(a) - getIssueTotalSeconds(b);
+    case 'priority':
+      return getIssuePriorityRank(b) - getIssuePriorityRank(a);
+    default:
+      return 0;
+  }
+}
+
+function getIssueDateMs(issue: JiraIssue) {
+  const date = issue.fields.updated || issue.fields.created || '';
+  const parsed = Date.parse(date);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getIssueTotalSeconds(issue: JiraIssue) {
+  return sumWorklogSeconds(issue.fields.worklog?.worklogs || []);
+}
+
+function getIssuePriorityRank(issue: JiraIssue) {
+  const priorityName = (issue.fields.priority?.name || '').toLowerCase();
+  if (priorityName in PRIORITY_RANKS) return PRIORITY_RANKS[priorityName];
+
+  const numericId = Number(issue.fields.priority?.id);
+  if (Number.isFinite(numericId)) return -numericId;
+
+  return 0;
 }
 
 // ===== Cell builders (one per column id) =====
@@ -1408,7 +1534,7 @@ async function toggleStar(issueId: string, options: PopupOptions) {
     const issuesResponse = await JIRA.getIssues(0, options.jql);
 
     // Redraw table so starred item jumps to top
-    drawIssuesTable(issuesResponse, options);
+    await onFetchSuccess(issuesResponse, options);
 
     // ⭐️ Re-run your frequent-worklog setup after the new table is in the DOM
     insertFrequentWorklogDescription(options);

--- a/src/ts/shared/jira-api.ts
+++ b/src/ts/shared/jira-api.ts
@@ -31,6 +31,7 @@ interface ApiSearchIssue {
     priority?: JiraIssue['fields']['priority'];
     created?: string;
     updated?: string;
+    timespent?: number | null;
   };
 }
 
@@ -266,7 +267,7 @@ async function JiraAPI(
       let total: number | null = null;
 
       while (aggregatedIssues.length < hardCap) {
-        const endpoint = `/search?jql=${encodeURIComponent(jql ?? '')}&fields=summary,parent,project,status,assignee,priority,created,updated,worklog&maxResults=${pageSize}&startAt=${startAt}`;
+        const endpoint = `/search?jql=${encodeURIComponent(jql ?? '')}&fields=summary,parent,project,status,assignee,priority,created,updated,timespent,worklog&maxResults=${pageSize}&startAt=${startAt}`;
         console.log(`Requesting issues from: ${endpoint}`);
         const resp = await apiRequest<ApiSearchResponse>(endpoint, 'GET');
         console.log(`Response from Jira:`, resp);
@@ -553,6 +554,7 @@ async function JiraAPI(
         'priority',
         'created',
         'updated',
+        'timespent',
         'worklog',
       ],
     };
@@ -625,6 +627,7 @@ async function JiraAPI(
             priority: i.fields?.priority ?? null,
             created: i.fields?.created,
             updated: i.fields?.updated,
+            timespent: i.fields?.timespent ?? null,
             worklog: i.fields?.worklog ?? { worklogs: [] },
           },
         };

--- a/src/ts/shared/jira-api.ts
+++ b/src/ts/shared/jira-api.ts
@@ -28,6 +28,9 @@ interface ApiSearchIssue {
     status?: JiraIssue['fields']['status'];
     assignee?: JiraIssue['fields']['assignee'];
     worklog?: JiraIssue['fields']['worklog'];
+    priority?: JiraIssue['fields']['priority'];
+    created?: string;
+    updated?: string;
   };
 }
 
@@ -263,7 +266,7 @@ async function JiraAPI(
       let total: number | null = null;
 
       while (aggregatedIssues.length < hardCap) {
-        const endpoint = `/search?jql=${encodeURIComponent(jql ?? '')}&fields=summary,parent,project,status,assignee&maxResults=${pageSize}&startAt=${startAt}`;
+        const endpoint = `/search?jql=${encodeURIComponent(jql ?? '')}&fields=summary,parent,project,status,assignee,priority,created,updated,worklog&maxResults=${pageSize}&startAt=${startAt}`;
         console.log(`Requesting issues from: ${endpoint}`);
         const resp = await apiRequest<ApiSearchResponse>(endpoint, 'GET');
         console.log(`Response from Jira:`, resp);
@@ -541,7 +544,17 @@ async function JiraAPI(
     } = {
       jql: jql || '',
       maxResults: maxResults || 100,
-      fields: ['summary', 'parent', 'project', 'status', 'assignee'],
+      fields: [
+        'summary',
+        'parent',
+        'project',
+        'status',
+        'assignee',
+        'priority',
+        'created',
+        'updated',
+        'worklog',
+      ],
     };
     if (nextPageToken) body.nextPageToken = nextPageToken;
     return apiRequest<ApiSearchResponse>(endpoint, 'POST', body);
@@ -609,6 +622,9 @@ async function JiraAPI(
             project: i.fields?.project ?? null,
             status: i.fields?.status ?? null,
             assignee: i.fields?.assignee ?? null,
+            priority: i.fields?.priority ?? null,
+            created: i.fields?.created,
+            updated: i.fields?.updated,
             worklog: i.fields?.worklog ?? { worklogs: [] },
           },
         };

--- a/src/ts/shared/types.ts
+++ b/src/ts/shared/types.ts
@@ -51,6 +51,7 @@ export interface JiraIssueFields {
   priority?: JiraPriority | null;
   created?: string;
   updated?: string;
+  timespent?: number | null;
   worklog?: JiraWorklogResponse;
   [key: string]: unknown;
 }

--- a/src/ts/shared/types.ts
+++ b/src/ts/shared/types.ts
@@ -25,6 +25,11 @@ export interface JiraStatus {
   name?: string;
 }
 
+export interface JiraPriority {
+  id?: string;
+  name?: string;
+}
+
 export interface JiraWorklog {
   started?: string;
   timeSpentSeconds: number;
@@ -43,6 +48,9 @@ export interface JiraIssueFields {
   project?: JiraProjectRef | null;
   status?: JiraStatus | null;
   assignee?: JiraUser | null;
+  priority?: JiraPriority | null;
+  created?: string;
+  updated?: string;
   worklog?: JiraWorklogResponse;
   [key: string]: unknown;
 }
@@ -150,12 +158,21 @@ export interface PopupColumnVisibility {
   [key: string]: boolean;
 }
 
+export type TimeTableSort =
+  | 'default'
+  | 'dateNewest'
+  | 'dateOldest'
+  | 'totalDesc'
+  | 'totalAsc'
+  | 'priority';
+
 export interface PopupOptions extends BaseExtensionOptions {
   jql: string;
   starredIssues: Record<string, number>;
   defaultPage: string;
   timeTableColumns: PopupColumnVisibility;
   timeTableColumnOrder: string[];
+  timeTableSort: TimeTableSort;
 }
 
 export interface TimerOptions extends BaseExtensionOptions {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> User-facing sort preference and broader Jira field requests; no auth or write-path changes. Unknown priority names sort as rank 0, which may cluster those issues together.
> 
> **Overview**
> Adds a **Sort** control to the Time Table gear settings so users can order issues (while **starred rows still stay on top**). Choices include default Jira order, updated date, logged time, and priority.
> 
> The preference is stored as `timeTableSort` in `chrome.storage.sync`, normalized on load, and applied when the table is drawn via new `sortIssues` / `compareIssues` helpers (replacing star-only sorting).
> 
> Jira issue search now requests **`priority`, `created`, `updated`, `timespent`, and `worklog`** so sorting and totals work without extra calls when `timespent` is present. The gear modal is slightly wider and includes select styling for light/dark mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60abfca5d2a281ad14e7afc8ab219c5700bd501. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->