### PR TITLE
Add weekly calendar time entry view

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -11,6 +11,7 @@
         height: 100%;
         width: 100%;
         min-width: 750px;
+        background-color: #ffffff;
       }
 
       /* Toolbar popup: overall width 750px (border-box; no extra px from side padding). */
@@ -21,6 +22,7 @@
         box-sizing: border-box;
         padding: 0;
         min-height: 100%;
+        background-color: #ffffff;
       }
 
       /* Experimental + Page View: fluid width up to 1400px (same as full-tab pages). */
@@ -508,6 +510,10 @@
         color: #e0e0e0;
       }
 
+      html.dark-mode {
+        background-color: #141414;
+      }
+
       body.dark-mode input,
       body.dark-mode textarea,
       body.dark-mode select {
@@ -660,6 +666,201 @@
         padding-bottom: 50px;
       }
 
+      .view-toolbar {
+        display: none;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 6px;
+        padding: 6px 0 4px;
+        margin: 0 3px;
+      }
+
+      .week-controls {
+        display: none;
+        align-items: center;
+        gap: 4px;
+        margin-left: auto;
+      }
+
+      .week-nav-btn,
+      #week-today-btn {
+        width: auto;
+        border: 1px solid #c8d4e5;
+        background: #fff;
+        color: #253858;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 12px;
+        line-height: 1;
+        padding: 5px 7px;
+      }
+
+      .week-nav-btn {
+        min-width: 26px;
+      }
+
+      .week-nav-btn:hover,
+      #week-today-btn:hover {
+        background: #eef4ff;
+        border-color: #0052cc;
+      }
+
+      .week-settings-btn {
+        margin-left: 4px;
+        border: 1px solid #c8d4e5;
+        background: #fff;
+      }
+
+      .week-settings-btn:hover {
+        border-color: #0052cc;
+      }
+
+      #week-range-label {
+        min-width: 128px;
+        text-align: center;
+        color: #253858;
+        font-size: 12px;
+        font-weight: bold;
+      }
+
+      #week-view {
+        display: none;
+        overflow-x: auto;
+        padding-bottom: 8px;
+      }
+
+      #weekly-log-table {
+        min-width: 0;
+        width: 100%;
+        table-layout: fixed;
+        margin: 0;
+      }
+
+      #weekly-log-table th,
+      #weekly-log-table td {
+        padding: 4px 3px;
+        text-align: center;
+        vertical-align: middle;
+      }
+
+      #weekly-log-table th {
+        text-align: center;
+      }
+
+      #weekly-log-table th.weekly-issue-heading {
+        width: 16%;
+      }
+
+      #weekly-log-table th.weekly-day-heading {
+        width: 10.4%;
+      }
+
+      #weekly-log-table th.weekly-total-heading {
+        width: 6%;
+      }
+
+      #weekly-log-table th.weekly-action-heading {
+        width: 5%;
+      }
+
+      .weekly-issue-cell {
+        font-size: 10px;
+        line-height: 1.25;
+        text-align: center;
+      }
+
+      .weekly-issue-key {
+        display: inline-block;
+        font-weight: bold;
+        margin-bottom: 3px;
+      }
+
+      .weekly-issue-summary {
+        color: #5e6c84;
+        max-height: 38px;
+        text-align: center;
+      }
+
+      .weekly-day-label {
+        display: block;
+        font-weight: bold;
+      }
+
+      .weekly-date-label {
+        display: block;
+        margin-top: 1px;
+        color: #5e6c84;
+        font-size: 10px;
+        font-weight: normal;
+      }
+
+      .weekly-entry {
+        display: grid;
+        align-content: center;
+        align-items: center;
+        gap: 3px;
+        height: 100%;
+      }
+
+      .weekly-logged-time {
+        min-height: 12px;
+        color: #4f8a10;
+        font-size: 9px;
+        font-weight: bold;
+        line-height: 1.2;
+      }
+
+      .weekly-time-input,
+      .weekly-comment-input {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 3px 2px;
+        font-size: 10px;
+        border-radius: 4px;
+        font-family: Arial, sans-serif;
+        text-align: center;
+      }
+
+      .weekly-comment-input {
+        min-height: 34px;
+        line-height: 1.2;
+        resize: vertical;
+      }
+
+      .weekly-row-total,
+      .weekly-day-total,
+      .weekly-grand-total {
+        font-weight: bold;
+        text-align: center;
+        white-space: nowrap;
+      }
+
+      .weekly-log-btn {
+        width: 100%;
+        background: #0052cc;
+        color: #fff;
+        border-radius: 3px;
+        border: none;
+        padding: 5px 2px;
+        font-size: 10px;
+        cursor: pointer;
+      }
+
+      .weekly-log-btn:hover {
+        background: #0041a8;
+      }
+
+      .weekly-log-btn:disabled {
+        cursor: wait;
+        opacity: 0.65;
+      }
+
+      .weekly-empty {
+        padding: 20px;
+        text-align: center;
+        color: #5e6c84;
+      }
+
       /* Theme Toggle Styles */
       .theme-toggle {
         display: inline-flex;
@@ -799,6 +1000,41 @@
         background-color: rgba(255, 255, 255, 0.2);
       }
 
+      body.dark-mode .week-nav-btn,
+      body.dark-mode #week-today-btn,
+      body.dark-mode .week-settings-btn {
+        background: #1a1a1a;
+        border-color: #333;
+        color: #e0e0e0;
+      }
+
+      body.dark-mode .week-nav-btn:hover,
+      body.dark-mode #week-today-btn:hover,
+      body.dark-mode .week-settings-btn:hover {
+        background: #252525;
+        border-color: #4690dd;
+      }
+
+      body.dark-mode #week-range-label,
+      body.dark-mode .weekly-issue-summary,
+      body.dark-mode .weekly-date-label,
+      body.dark-mode .weekly-empty {
+        color: #aaa;
+      }
+
+      body.dark-mode .weekly-log-btn {
+        background: #4690dd;
+        color: #1a1a1a;
+      }
+
+      body.dark-mode .weekly-log-btn:hover {
+        background: #5e9fe3;
+      }
+
+      body.dark-mode .weekly-logged-time {
+        color: #90ee90;
+      }
+
       body.dark-mode .caret-button:hover,
       body.dark-mode .caret-button:focus,
       body.dark-mode .caret-button:focus-visible {
@@ -896,7 +1132,7 @@
       }
 
       /* ===== Gear button inside actions header cell ===== */
-      #gearBtn {
+      .gear-btn {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -910,17 +1146,17 @@
         color: #0052cc;
         vertical-align: middle;
       }
-      #gearBtn:hover {
+      .gear-btn:hover {
         background: rgba(0, 82, 204, 0.12);
         color: #0041a8;
       }
-      #gearBtn svg {
+      .gear-btn svg {
         display: block;
       }
-      body.dark-mode #gearBtn {
+      body.dark-mode .gear-btn {
         color: #4690dd;
       }
-      body.dark-mode #gearBtn:hover {
+      body.dark-mode .gear-btn:hover {
         background: rgba(70, 144, 221, 0.2);
         color: #7eb4f0;
       }
@@ -1111,6 +1347,30 @@
         outline: none;
         border-color: #0052cc;
       }
+      .gear-toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 8px;
+        background: #f5f5f5;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+      }
+      .gear-toggle-row label {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        width: 100%;
+        cursor: pointer;
+        font-size: 11px;
+      }
+      .gear-toggle-row input[type='checkbox'] {
+        width: auto;
+        margin: 0;
+        cursor: pointer;
+      }
       #gear-column-order {
         list-style: none;
         padding: 0;
@@ -1216,6 +1476,11 @@
       body.dark-mode .gear-section select:focus {
         border-color: #4690dd;
       }
+      body.dark-mode .gear-toggle-row {
+        background: #252525;
+        border-color: #333;
+        color: #e0e0e0;
+      }
       body.dark-mode #gear-column-order li {
         background: #252525;
         border-color: #333;
@@ -1253,12 +1518,45 @@
     <div id="error"></div>
     <div id="success"></div>
     <div id="table-container">
-      <table id="jira-log-time-table">
-        <thead>
-          <tr></tr>
-        </thead>
-        <!-- <tbody> is created dynamically by dist/popup.js -->
-      </table>
+      <div class="view-toolbar">
+        <div id="week-controls" class="week-controls">
+          <button
+            id="week-prev-btn"
+            class="week-nav-btn"
+            type="button"
+            title="Previous week"
+            aria-label="Previous week"
+          >
+            ‹
+          </button>
+          <span id="week-range-label"></span>
+          <button id="week-today-btn" type="button">Today</button>
+          <button
+            id="week-next-btn"
+            class="week-nav-btn"
+            type="button"
+            title="Next week"
+            aria-label="Next week"
+          >
+            ›
+          </button>
+        </div>
+      </div>
+      <div id="table-view">
+        <table id="jira-log-time-table">
+          <thead>
+            <tr></tr>
+          </thead>
+          <!-- <tbody> is created dynamically by dist/popup.js -->
+        </table>
+      </div>
+      <div id="week-view">
+        <table id="weekly-log-table">
+          <thead></thead>
+          <tbody></tbody>
+          <tfoot></tfoot>
+        </table>
+      </div>
       <div id="loader-container">
         <div class="loader"></div>
       </div>
@@ -1333,6 +1631,15 @@
           <button id="gear-modal-close">&times;</button>
         </div>
         <div id="gear-modal-body">
+          <div class="gear-section">
+            <div class="gear-section-title">View</div>
+            <div class="gear-toggle-row">
+              <label for="gear-week-view-toggle">
+                <span>Weekly calendar view</span>
+                <input id="gear-week-view-toggle" type="checkbox" />
+              </label>
+            </div>
+          </div>
           <div class="gear-section">
             <div class="gear-section-title">
               <a

--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -27,6 +27,54 @@ type CachedIssuesResponse = {
   ts: number;
 };
 
+type TimeEntryView = 'table' | 'week';
+
+type WeeklyEntry = {
+  date: string;
+  duration: string;
+  comment: string;
+  seconds: number;
+};
+
+type WeeklyLoggedIssuesCacheEntry = {
+  data: JiraIssuesResponse;
+  ts: number;
+};
+
+type WeeklyWorklogTotals = Record<string, Record<string, number>>;
+
+type WeeklyWorklogTotalsCacheEntry = {
+  data: WeeklyWorklogTotals;
+  ts: number;
+};
+
+const WEEKDAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const WEEKLY_LOGGED_ISSUES_CACHE_TTL_MS = 5 * 60 * 1000;
+const WEEKLY_WORKLOG_TOTALS_CACHE_TTL_MS = 60 * 1000;
+const GEAR_ICON_SVG =
+  '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M6.5.5a.5.5 0 0 0-.5.5v1.07a5.5 5.5 0 0 0-1.56.64L3.7 1.97a.5.5 0 0 0-.7 0l-.71.7a.5.5 0 0 0 0 .71l.74.74A5.5 5.5 0 0 0 2.4 5.7H1.3a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1.1a5.5 5.5 0 0 0 .63 1.58l-.74.74a.5.5 0 0 0 0 .7l.71.71a.5.5 0 0 0 .7 0l.74-.74a5.5 5.5 0 0 0 1.56.64V12.5a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1.07a5.5 5.5 0 0 0 1.56-.64l.74.74a.5.5 0 0 0 .7 0l.71-.7a.5.5 0 0 0 0-.71l-.74-.74A5.5 5.5 0 0 0 11.6 7.7h1.1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5h-1.1a5.5 5.5 0 0 0-.63-1.58l.74-.74a.5.5 0 0 0 0-.7l-.71-.71a.5.5 0 0 0-.7 0l-.74.74A5.5 5.5 0 0 0 8 2.07V1a.5.5 0 0 0-.5-.5h-1zM7 4.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5z"/></svg>';
+
+let activeTimeEntryView: TimeEntryView = 'table';
+let currentWeekStart = getStartOfWeek(new Date());
+let currentIssuesResponse: JiraIssuesResponse | null = null;
+let currentIssuesResponseVersion = 0;
+let currentPopupOptions: PopupOptions | null = null;
+let viewControlsInitialized = false;
+const weeklyLoggedIssuesCache = new Map<string, WeeklyLoggedIssuesCacheEntry>();
+const weeklyLoggedIssuesRequests = new Map<
+  string,
+  Promise<JiraIssuesResponse>
+>();
+const weeklyWorklogTotalsCache = new Map<
+  string,
+  WeeklyWorklogTotalsCacheEntry
+>();
+const weeklyWorklogTotalsRequests = new Map<
+  string,
+  Promise<WeeklyWorklogTotals>
+>();
+let weeklyWorklogTotalsVersion = 0;
+
 // ===== Column model =====
 const COLUMN_DEFS = {
   issueId: { label: 'Jira ID', baseWidth: 14, locked: 'first', hasLogo: true },
@@ -131,6 +179,454 @@ function normalizeColumnOrder(stored: unknown): ColumnId[] {
   return ['issueId', ...withoutLocked, 'actions'];
 }
 
+function getStartOfWeek(date: Date): Date {
+  const weekStart = new Date(date);
+  weekStart.setHours(0, 0, 0, 0);
+  const day = weekStart.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  weekStart.setDate(weekStart.getDate() + diff);
+  return weekStart;
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function formatDateInputValue(date: Date): string {
+  const local = new Date(date);
+  local.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+  return local.toJSON().slice(0, 10);
+}
+
+function formatWeeklyDateKey(date: Date): string {
+  return formatDateInputValue(date);
+}
+
+function formatShortDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function getWeekDates(): Date[] {
+  return WEEKDAY_LABELS.map((_label, index) =>
+    addDays(currentWeekStart, index)
+  );
+}
+
+function getWeekDateRange() {
+  return {
+    start: formatWeeklyDateKey(currentWeekStart),
+    end: formatWeeklyDateKey(addDays(currentWeekStart, 6)),
+  };
+}
+
+function formatInputTotal(seconds: number): string {
+  if (seconds <= 0) return '0h';
+  const hours = seconds / 3600;
+  return `${Number.isInteger(hours) ? hours.toFixed(0) : hours.toFixed(1)}h`;
+}
+
+function getJiraIssueUrl(issueId: string, options: PopupOptions): string {
+  const baseUrl = options.baseUrl.startsWith('http')
+    ? options.baseUrl
+    : `https://${options.baseUrl}`;
+  const normalizedBaseUrl = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return `${normalizedBaseUrl}browse/${issueId}`;
+}
+
+function getWeeklyLoggedIssuesCacheKey(options: PopupOptions): string {
+  const { start, end } = getWeekDateRange();
+  return [
+    'weeklyLoggedIssues',
+    options.jiraType,
+    options.baseUrl,
+    options.username,
+    start,
+    end,
+  ].join(':');
+}
+
+function getWeeklyCachePrefix(options: PopupOptions): string {
+  const { start, end } = getWeekDateRange();
+  return [options.jiraType, options.baseUrl, options.username, start, end].join(
+    ':'
+  );
+}
+
+function getWeeklyWorklogTotalsCacheKey(
+  options: PopupOptions,
+  issueKeys: string[]
+): string {
+  return [
+    'weeklyWorklogTotals',
+    getWeeklyCachePrefix(options),
+    issueKeys.slice().sort().join(','),
+  ].join(':');
+}
+
+function buildWeeklyLoggedIssuesJql(): string {
+  const { start, end } = getWeekDateRange();
+  return (
+    'worklogAuthor = currentUser() ' +
+    `AND worklogDate >= "${start}" ` +
+    `AND worklogDate <= "${end}" ` +
+    'ORDER BY updated DESC'
+  );
+}
+
+function mergeIssueResponses(
+  baseIssuesResponse: JiraIssuesResponse,
+  loggedIssuesResponse: JiraIssuesResponse
+): JiraIssuesResponse {
+  const byKey = new Map<string, JiraIssue>();
+
+  (baseIssuesResponse.data || []).forEach((issue) => {
+    byKey.set(issue.key, issue);
+  });
+
+  (loggedIssuesResponse.data || []).forEach((issue) => {
+    const existing = byKey.get(issue.key);
+    if (existing) {
+      byKey.set(issue.key, {
+        key: existing.key,
+        fields: {
+          ...issue.fields,
+          ...existing.fields,
+        },
+      });
+      return;
+    }
+
+    byKey.set(issue.key, issue);
+  });
+
+  const data = Array.from(byKey.values());
+  return {
+    total: data.length,
+    data,
+  };
+}
+
+function getWorklogDateKey(worklog: JiraWorklog): string | null {
+  if (!worklog.started) return null;
+  const startedDate = new Date(worklog.started);
+  if (isNaN(startedDate.getTime())) return null;
+  return formatWeeklyDateKey(startedDate);
+}
+
+function isWorklogByCurrentUser(
+  worklog: JiraWorklog,
+  currentUser: Awaited<ReturnType<JiraApiClient['login']>> | null,
+  options: PopupOptions
+): boolean {
+  const author = worklog.author;
+  if (!author) return false;
+
+  if (currentUser) {
+    if (
+      currentUser.accountId &&
+      author.accountId &&
+      currentUser.accountId === author.accountId
+    ) {
+      return true;
+    }
+
+    if (
+      currentUser.emailAddress &&
+      author.emailAddress &&
+      currentUser.emailAddress.toLowerCase() ===
+        author.emailAddress.toLowerCase()
+    ) {
+      return true;
+    }
+  }
+
+  const configuredUsername = options.username?.toLowerCase();
+  if (configuredUsername) {
+    return [author.name, author.key, author.emailAddress]
+      .filter((value): value is string => !!value)
+      .some((value) => value.toLowerCase() === configuredUsername);
+  }
+
+  return false;
+}
+
+function addWeeklyWorklogTotal(
+  totals: WeeklyWorklogTotals,
+  issueKey: string,
+  dateKey: string,
+  seconds: number
+) {
+  if (!totals[issueKey]) totals[issueKey] = {};
+  totals[issueKey][dateKey] = (totals[issueKey][dateKey] || 0) + seconds;
+}
+
+async function loadWeeklyWorklogTotals(
+  options: PopupOptions,
+  issuesResponse: JiraIssuesResponse
+): Promise<WeeklyWorklogTotals> {
+  const issueKeys = (issuesResponse.data || []).map((issue) => issue.key);
+  if (issueKeys.length === 0) return {};
+
+  const cacheKey = getWeeklyWorklogTotalsCacheKey(options, issueKeys);
+  const cached = weeklyWorklogTotalsCache.get(cacheKey);
+  if (cached && Date.now() - cached.ts < WEEKLY_WORKLOG_TOTALS_CACHE_TTL_MS) {
+    return cached.data;
+  }
+
+  const existingRequest = weeklyWorklogTotalsRequests.get(cacheKey);
+  if (existingRequest) return existingRequest;
+
+  const weekDates = new Set(getWeekDates().map(formatWeeklyDateKey));
+  const worklogTotalsVersion = weeklyWorklogTotalsVersion;
+  const request = (async () => {
+    const JIRA = await getSharedJira(options);
+    let currentUser: Awaited<ReturnType<JiraApiClient['login']>> | null = null;
+    try {
+      currentUser = await JIRA.login();
+    } catch (error) {
+      console.warn('Failed to resolve Jira user for worklog filtering:', error);
+    }
+
+    const totals: WeeklyWorklogTotals = {};
+    await Promise.all(
+      issueKeys.map(async (issueKey) => {
+        try {
+          const response = await JIRA.getIssueWorklog(issueKey);
+          (response.worklogs || []).forEach((worklog) => {
+            if (!isWorklogByCurrentUser(worklog, currentUser, options)) return;
+
+            const dateKey = getWorklogDateKey(worklog);
+            if (!dateKey || !weekDates.has(dateKey)) return;
+
+            addWeeklyWorklogTotal(
+              totals,
+              issueKey,
+              dateKey,
+              worklog.timeSpentSeconds
+            );
+          });
+        } catch (error) {
+          console.warn(`Failed to load worklogs for ${issueKey}:`, error);
+        }
+      })
+    );
+
+    if (weeklyWorklogTotalsVersion === worklogTotalsVersion) {
+      weeklyWorklogTotalsCache.set(cacheKey, { data: totals, ts: Date.now() });
+    }
+    return totals;
+  })();
+
+  weeklyWorklogTotalsRequests.set(cacheKey, request);
+
+  try {
+    return await request;
+  } finally {
+    weeklyWorklogTotalsRequests.delete(cacheKey);
+  }
+}
+
+function clearWeeklyWorklogCaches() {
+  weeklyWorklogTotalsVersion += 1;
+  weeklyWorklogTotalsCache.clear();
+  weeklyWorklogTotalsRequests.clear();
+}
+
+async function loadLoggedIssuesForCurrentWeek(
+  options: PopupOptions
+): Promise<JiraIssuesResponse> {
+  const cacheKey = getWeeklyLoggedIssuesCacheKey(options);
+  const cached = weeklyLoggedIssuesCache.get(cacheKey);
+  if (cached && Date.now() - cached.ts < WEEKLY_LOGGED_ISSUES_CACHE_TTL_MS) {
+    return cached.data;
+  }
+
+  const existingRequest = weeklyLoggedIssuesRequests.get(cacheKey);
+  if (existingRequest) return existingRequest;
+
+  const jql = buildWeeklyLoggedIssuesJql();
+  const request = (async () => {
+    const JIRA = await getSharedJira(options);
+    const data = await JIRA.getIssues(0, jql);
+    weeklyLoggedIssuesCache.set(cacheKey, { data, ts: Date.now() });
+    return data;
+  })();
+
+  weeklyLoggedIssuesRequests.set(cacheKey, request);
+
+  try {
+    return await request;
+  } finally {
+    weeklyLoggedIssuesRequests.delete(cacheKey);
+  }
+}
+
+function initViewControls() {
+  if (viewControlsInitialized) return;
+  viewControlsInitialized = true;
+
+  const weekControls = document.getElementById('week-controls');
+  const prevBtn = document.getElementById(
+    'week-prev-btn'
+  ) as HTMLButtonElement | null;
+  const nextBtn = document.getElementById(
+    'week-next-btn'
+  ) as HTMLButtonElement | null;
+  const todayBtn = document.getElementById(
+    'week-today-btn'
+  ) as HTMLButtonElement | null;
+
+  prevBtn?.addEventListener('click', () => {
+    currentWeekStart = addDays(currentWeekStart, -7);
+    void renderCurrentWeeklyView();
+  });
+  nextBtn?.addEventListener('click', () => {
+    currentWeekStart = addDays(currentWeekStart, 7);
+    void renderCurrentWeeklyView();
+  });
+  todayBtn?.addEventListener('click', () => {
+    currentWeekStart = getStartOfWeek(new Date());
+    void renderCurrentWeeklyView();
+  });
+
+  if (weekControls && !document.getElementById('week-gear-btn')) {
+    const weekGearBtn = buildGearButton();
+    weekGearBtn.id = 'week-gear-btn';
+    weekGearBtn.classList.add('week-settings-btn');
+    weekControls.appendChild(weekGearBtn);
+  }
+
+  setTimeEntryView(activeTimeEntryView);
+}
+
+function setTimeEntryView(view: TimeEntryView) {
+  activeTimeEntryView = view;
+
+  const viewToolbar = document.querySelector<HTMLElement>('.view-toolbar');
+  const tableView = document.getElementById('table-view');
+  const weekView = document.getElementById('week-view');
+  const weekControls = document.getElementById('week-controls');
+
+  if (tableView) tableView.style.display = view === 'table' ? 'block' : 'none';
+  if (weekView) weekView.style.display = view === 'week' ? 'block' : 'none';
+  if (viewToolbar)
+    viewToolbar.style.display = view === 'week' ? 'flex' : 'none';
+  if (weekControls) {
+    weekControls.style.display = view === 'week' ? 'flex' : 'none';
+  }
+
+  if (view === 'week') {
+    void renderCurrentWeeklyView();
+  }
+}
+
+async function renderCurrentWeeklyView() {
+  if (!currentIssuesResponse || !currentPopupOptions) {
+    updateWeekRangeLabel();
+    return;
+  }
+
+  const options = currentPopupOptions;
+  const baseIssuesResponse = currentIssuesResponse;
+  const issueVersion = currentIssuesResponseVersion;
+  const cacheKey = getWeeklyLoggedIssuesCacheKey(options);
+
+  const cached = weeklyLoggedIssuesCache.get(cacheKey);
+  if (cached && Date.now() - cached.ts < WEEKLY_LOGGED_ISSUES_CACHE_TTL_MS) {
+    const mergedIssuesResponse = mergeIssueResponses(
+      baseIssuesResponse,
+      cached.data
+    );
+    drawWeeklyView(mergedIssuesResponse, options);
+    await loadAndRenderWeeklyWorklogTotals(
+      mergedIssuesResponse,
+      options,
+      cacheKey,
+      issueVersion
+    );
+    return;
+  }
+
+  drawWeeklyLoadingState(baseIssuesResponse, options);
+
+  try {
+    const loggedIssuesResponse = await loadLoggedIssuesForCurrentWeek(options);
+    if (
+      activeTimeEntryView !== 'week' ||
+      currentPopupOptions !== options ||
+      currentIssuesResponseVersion !== issueVersion ||
+      getWeeklyLoggedIssuesCacheKey(options) !== cacheKey
+    ) {
+      return;
+    }
+
+    const mergedIssuesResponse = mergeIssueResponses(
+      baseIssuesResponse,
+      loggedIssuesResponse
+    );
+    drawWeeklyView(mergedIssuesResponse, options);
+    await loadAndRenderWeeklyWorklogTotals(
+      mergedIssuesResponse,
+      options,
+      cacheKey,
+      issueVersion
+    );
+  } catch (error) {
+    console.warn('Failed to load historical weekly issues:', error);
+    if (
+      activeTimeEntryView === 'week' &&
+      currentPopupOptions === options &&
+      currentIssuesResponseVersion === issueVersion &&
+      getWeeklyLoggedIssuesCacheKey(options) === cacheKey
+    ) {
+      drawWeeklyView(baseIssuesResponse, options);
+      window.JiraErrorHandler?.handleJiraError(
+        error,
+        'Failed to load issues with work logged for this week',
+        'popup'
+      );
+    }
+  }
+}
+
+async function loadAndRenderWeeklyWorklogTotals(
+  issuesResponse: JiraIssuesResponse,
+  options: PopupOptions,
+  loggedIssuesCacheKey: string,
+  issueVersion: number
+) {
+  try {
+    const worklogTotalsVersion = weeklyWorklogTotalsVersion;
+    const totals = await loadWeeklyWorklogTotals(options, issuesResponse);
+    if (
+      activeTimeEntryView !== 'week' ||
+      currentPopupOptions !== options ||
+      currentIssuesResponseVersion !== issueVersion ||
+      weeklyWorklogTotalsVersion !== worklogTotalsVersion ||
+      getWeeklyLoggedIssuesCacheKey(options) !== loggedIssuesCacheKey
+    ) {
+      return;
+    }
+
+    applyWeeklyWorklogTotals(totals);
+  } catch (error) {
+    console.warn('Failed to load weekly worklog totals:', error);
+  }
+}
+
+function updateWeekRangeLabel() {
+  const rangeLabel = document.getElementById('week-range-label');
+  if (!rangeLabel) return;
+
+  const weekEnd = addDays(currentWeekStart, 6);
+  rangeLabel.textContent = `${formatShortDate(currentWeekStart)} - ${formatShortDate(weekEnd)}`;
+}
+
 // ===== Theme =====
 document.addEventListener('DOMContentLoaded', function () {
   const themeToggle = document.getElementById('themeToggle');
@@ -155,6 +651,7 @@ async function onDOMContentLoaded() {
       frequentWorklogDescription2: '',
       starredIssues: {},
       defaultPage: 'popup.html',
+      timeEntryView: 'table',
       darkMode: false,
       experimentalFeatures: false,
       timeTableColumns: DEFAULT_TIME_TABLE_COLUMNS,
@@ -173,6 +670,9 @@ async function onDOMContentLoaded() {
         options.timeTableColumnOrder
       );
       options.timeTableSort = normalizeTimeTableSort(options.timeTableSort);
+      options.timeEntryView =
+        options.timeEntryView === 'week' ? 'week' : 'table';
+      activeTimeEntryView = options.timeEntryView;
 
       const urlParams = new URLSearchParams(window.location.search);
       const isNavigatingBack = urlParams.get('source') === 'navigation';
@@ -193,6 +693,7 @@ async function onDOMContentLoaded() {
       window._ttOptions = options;
 
       initGearPanel(options);
+      initViewControls();
       await init(options);
       insertFrequentWorklogDescription(options);
     }
@@ -243,6 +744,11 @@ function syncGearPanelState(options: PopupOptions) {
   ) as HTMLSelectElement | null;
   if (sortSelect) sortSelect.value = options.timeTableSort;
 
+  const weekViewToggle = document.getElementById(
+    'gear-week-view-toggle'
+  ) as HTMLInputElement | null;
+  if (weekViewToggle) weekViewToggle.checked = activeTimeEntryView === 'week';
+
   renderGearColumnOrder(
     options.timeTableColumnOrder.filter(isColumnId),
     options.timeTableColumns
@@ -255,8 +761,9 @@ function openGearModal(options: PopupOptions | undefined = window._ttOptions) {
     'gear-modal-backdrop'
   ) as HTMLDivElement;
   backdrop.style.display = 'flex';
-  const btn = document.getElementById('gearBtn');
-  if (btn) btn.setAttribute('aria-expanded', 'true');
+  document
+    .querySelectorAll('.gear-btn')
+    .forEach((btn) => btn.setAttribute('aria-expanded', 'true'));
 }
 
 function closeGearModal() {
@@ -264,8 +771,9 @@ function closeGearModal() {
     'gear-modal-backdrop'
   ) as HTMLDivElement;
   backdrop.style.display = 'none';
-  const btn = document.getElementById('gearBtn');
-  if (btn) btn.setAttribute('aria-expanded', 'false');
+  document
+    .querySelectorAll('.gear-btn')
+    .forEach((btn) => btn.setAttribute('aria-expanded', 'false'));
 }
 
 function initGearPanel(options: PopupOptions) {
@@ -285,6 +793,9 @@ function initGearPanel(options: PopupOptions) {
   const sortSelect = document.getElementById(
     'gear-time-table-sort'
   ) as HTMLSelectElement;
+  const weekViewToggle = document.getElementById(
+    'gear-week-view-toggle'
+  ) as HTMLInputElement;
 
   syncGearPanelState(options);
 
@@ -302,21 +813,25 @@ function initGearPanel(options: PopupOptions) {
     const newCols = readGearColumnVisibility();
     const newOrder = readGearColumnOrder();
     const newSort = normalizeTimeTableSort(sortSelect.value);
+    const nextView: TimeEntryView = weekViewToggle.checked ? 'week' : 'table';
     const jqlChanged = newJql !== options.jql;
 
     options.jql = newJql;
     options.timeTableColumns = newCols;
     options.timeTableColumnOrder = newOrder;
     options.timeTableSort = newSort;
+    options.timeEntryView = nextView;
 
     chrome.storage.sync.set({
       jql: newJql,
+      timeEntryView: nextView,
       timeTableColumns: newCols,
       timeTableColumnOrder: newOrder,
       timeTableSort: newSort,
     });
 
     closeGearModal();
+    setTimeEntryView(nextView);
 
     if (jqlChanged) {
       // Refetch with new JQL
@@ -491,6 +1006,18 @@ function buildHTML(
   return element;
 }
 
+function buildGearButton(): HTMLButtonElement {
+  const gearBtn = document.createElement('button');
+  gearBtn.type = 'button';
+  gearBtn.className = 'gear-btn';
+  gearBtn.title = 'Time Table settings';
+  gearBtn.setAttribute('aria-expanded', 'false');
+  gearBtn.setAttribute('aria-controls', 'gear-modal-backdrop');
+  gearBtn.innerHTML = GEAR_ICON_SVG;
+  gearBtn.addEventListener('click', () => openGearModal());
+  return gearBtn;
+}
+
 async function getSharedJira(options: PopupOptions): Promise<JiraApiClient> {
   const jiraConfig = {
     jiraType: options.jiraType,
@@ -552,7 +1079,12 @@ function removeTimeTableCacheEntries(baseUrl: string) {
 
 function clearTimeTableRows(options: PopupOptions) {
   clearMessages();
-  drawIssuesTable({ data: [], total: 0 }, options);
+  const emptyResponse = { data: [], total: 0 };
+  currentIssuesResponse = emptyResponse;
+  currentIssuesResponseVersion += 1;
+  currentPopupOptions = options;
+  drawIssuesTable(emptyResponse, options);
+  drawWeeklyView(emptyResponse, options);
 }
 
 async function clearCachedTimeTableData(options: PopupOptions) {
@@ -679,8 +1211,14 @@ function onFetchSuccess(
   options: PopupOptions
 ) {
   clearMessages();
+  currentIssuesResponse = issuesResponse;
+  currentIssuesResponseVersion += 1;
+  currentPopupOptions = options;
   console.log('Fetched issues:', issuesResponse);
   drawIssuesTable(issuesResponse, options);
+  if (activeTimeEntryView === 'week') {
+    void renderCurrentWeeklyView();
+  }
 }
 
 function getWorklog(issueId: string, JIRA: JiraApiClient) {
@@ -902,15 +1440,7 @@ function drawIssuesTable(
     if (colId === 'issueId') {
       th.innerHTML = `<img src="${chrome.runtime.getURL('src/icons/jira_logo.png')}" alt="Jira Logo" style="vertical-align:middle;margin-right:8px;width:16px;height:16px;"> Jira ID`;
     } else if (colId === 'actions') {
-      const gearBtn = document.createElement('button');
-      gearBtn.id = 'gearBtn';
-      gearBtn.title = 'Time Table settings';
-      gearBtn.setAttribute('aria-expanded', 'false');
-      gearBtn.setAttribute('aria-controls', 'gear-modal-backdrop');
-      gearBtn.innerHTML =
-        '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M6.5.5a.5.5 0 0 0-.5.5v1.07a5.5 5.5 0 0 0-1.56.64L3.7 1.97a.5.5 0 0 0-.7 0l-.71.7a.5.5 0 0 0 0 .71l.74.74A5.5 5.5 0 0 0 2.4 5.7H1.3a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1.1a5.5 5.5 0 0 0 .63 1.58l-.74.74a.5.5 0 0 0 0 .7l.71.71a.5.5 0 0 0 .7 0l.74-.74a5.5 5.5 0 0 0 1.56.64V12.5a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1.07a5.5 5.5 0 0 0 1.56-.64l.74.74a.5.5 0 0 0 .7 0l.71-.7a.5.5 0 0 0 0-.71l-.74-.74A5.5 5.5 0 0 0 11.6 7.7h1.1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5h-1.1a5.5 5.5 0 0 0-.63-1.58l.74-.74a.5.5 0 0 0 0-.7l-.71-.71a.5.5 0 0 0-.7 0l-.74.74A5.5 5.5 0 0 0 8 2.07V1a.5.5 0 0 0-.5-.5h-1zM7 4.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5z"/></svg>';
-      gearBtn.addEventListener('click', () => openGearModal());
-      th.appendChild(gearBtn);
+      th.appendChild(buildGearButton());
     } else {
       th.textContent = def.label;
     }
@@ -945,6 +1475,475 @@ function drawIssuesTable(
     });
 }
 
+function drawWeeklyView(
+  issuesResponse: JiraIssuesResponse,
+  options: PopupOptions
+) {
+  updateWeekRangeLabel();
+
+  const weeklyTable = document.getElementById('weekly-log-table');
+  if (!weeklyTable) return;
+
+  const thead = weeklyTable.querySelector('thead');
+  const tbody = weeklyTable.querySelector('tbody');
+  const tfoot = weeklyTable.querySelector('tfoot');
+  if (!thead || !tbody || !tfoot) return;
+
+  const weekDates = getWeekDates();
+  thead.innerHTML = '';
+  tbody.innerHTML = '';
+  tfoot.innerHTML = '';
+
+  const headerRow = document.createElement('tr');
+  const issueHeading = document.createElement('th');
+  issueHeading.className = 'weekly-issue-heading';
+  issueHeading.textContent = 'Issue';
+  headerRow.appendChild(issueHeading);
+
+  weekDates.forEach((date, index) => {
+    const dayHeading = document.createElement('th');
+    dayHeading.className = 'weekly-day-heading';
+    const dayLabel = document.createElement('span');
+    dayLabel.className = 'weekly-day-label';
+    dayLabel.textContent = WEEKDAY_LABELS[index];
+    const dateLabel = document.createElement('span');
+    dateLabel.className = 'weekly-date-label';
+    dateLabel.textContent = formatShortDate(date);
+    dayHeading.appendChild(dayLabel);
+    dayHeading.appendChild(dateLabel);
+    headerRow.appendChild(dayHeading);
+  });
+
+  const totalHeading = document.createElement('th');
+  totalHeading.className = 'weekly-total-heading';
+  totalHeading.textContent = 'Total';
+  headerRow.appendChild(totalHeading);
+
+  const actionHeading = document.createElement('th');
+  actionHeading.className = 'weekly-action-heading';
+  actionHeading.textContent = '';
+  headerRow.appendChild(actionHeading);
+  thead.appendChild(headerRow);
+
+  const issues = sortIssues(
+    issuesResponse.data || [],
+    options.starredIssues,
+    options.timeTableSort
+  );
+  if (issues.length === 0) {
+    const emptyRow = document.createElement('tr');
+    const emptyCell = document.createElement('td');
+    emptyCell.className = 'weekly-empty';
+    emptyCell.colSpan = weekDates.length + 3;
+    emptyCell.textContent = 'No issues match the current JQL.';
+    emptyRow.appendChild(emptyCell);
+    tbody.appendChild(emptyRow);
+  } else {
+    issues.forEach((issue) => {
+      tbody.appendChild(generateWeeklyIssueRow(issue, options, weekDates));
+    });
+  }
+
+  const footerRow = document.createElement('tr');
+  const labelCell = document.createElement('td');
+  labelCell.textContent = 'Daily totals';
+  labelCell.className = 'weekly-row-total';
+  footerRow.appendChild(labelCell);
+
+  weekDates.forEach((date) => {
+    const totalCell = document.createElement('td');
+    totalCell.className = 'weekly-day-total';
+    totalCell.setAttribute('data-weekly-total-date', formatWeeklyDateKey(date));
+    totalCell.textContent = '0h';
+    footerRow.appendChild(totalCell);
+  });
+
+  const grandTotalCell = document.createElement('td');
+  grandTotalCell.className = 'weekly-grand-total';
+  grandTotalCell.textContent = '0h';
+  footerRow.appendChild(grandTotalCell);
+  footerRow.appendChild(document.createElement('td'));
+  tfoot.appendChild(footerRow);
+
+  weeklyTable
+    .querySelectorAll<HTMLInputElement>('.weekly-comment-input')
+    .forEach((input) => initializeWorklogSuggestions(input));
+  updateWeeklyTotals();
+}
+
+function drawWeeklyLoadingState(
+  issuesResponse: JiraIssuesResponse,
+  options: PopupOptions
+) {
+  drawWeeklyView(issuesResponse, options);
+
+  const weeklyTable = document.getElementById('weekly-log-table');
+  const tbody = weeklyTable?.querySelector('tbody');
+  if (!tbody) return;
+
+  if ((issuesResponse.data || []).length === 0) {
+    tbody.innerHTML = '';
+  }
+
+  const loadingRow = document.createElement('tr');
+  const loadingCell = document.createElement('td');
+  loadingCell.className = 'weekly-empty';
+  loadingCell.colSpan = WEEKDAY_LABELS.length + 3;
+  loadingCell.textContent = 'Loading logged issues for this week...';
+  loadingRow.appendChild(loadingCell);
+  tbody.appendChild(loadingRow);
+}
+
+function generateWeeklyIssueRow(
+  issue: JiraIssue,
+  options: PopupOptions,
+  weekDates: Date[]
+): HTMLTableRowElement {
+  const row = document.createElement('tr');
+  row.className = 'weekly-issue-row';
+  row.setAttribute('data-weekly-issue-id', issue.key);
+
+  const issueCell = document.createElement('td');
+  issueCell.className = 'weekly-issue-cell';
+  const issueLink = document.createElement('a');
+  issueLink.className = 'weekly-issue-key';
+  issueLink.href = getJiraIssueUrl(issue.key, options);
+  issueLink.target = '_blank';
+  issueLink.textContent = issue.key;
+  const summary = document.createElement('div');
+  summary.className = 'weekly-issue-summary truncate';
+  summary.textContent = issue.fields.summary ?? '';
+  issueCell.appendChild(issueLink);
+  issueCell.appendChild(summary);
+  row.appendChild(issueCell);
+
+  weekDates.forEach((date) => {
+    const dateValue = formatWeeklyDateKey(date);
+    const cell = document.createElement('td');
+    const entry = document.createElement('div');
+    entry.className = 'weekly-entry';
+
+    const loggedTime = document.createElement('div');
+    loggedTime.className = 'weekly-logged-time';
+    loggedTime.setAttribute('data-weekly-logged-issue-id', issue.key);
+    loggedTime.setAttribute('data-weekly-logged-date', dateValue);
+    loggedTime.setAttribute('data-weekly-logged-seconds', '0');
+    loggedTime.textContent = '';
+
+    const timeInput = document.createElement('input');
+    timeInput.className = 'weekly-time-input';
+    timeInput.placeholder = '1h';
+    timeInput.setAttribute('data-weekly-issue-id', issue.key);
+    timeInput.setAttribute('data-weekly-date', dateValue);
+    timeInput.addEventListener('input', updateWeeklyTotals);
+
+    const commentInput = document.createElement('textarea');
+    commentInput.className = 'weekly-comment-input';
+    commentInput.placeholder = 'Comment';
+    commentInput.setAttribute('data-weekly-issue-id', issue.key);
+    commentInput.setAttribute('data-weekly-date', dateValue);
+
+    entry.appendChild(loggedTime);
+    entry.appendChild(timeInput);
+    entry.appendChild(commentInput);
+    cell.appendChild(entry);
+    row.appendChild(cell);
+  });
+
+  const rowTotal = document.createElement('td');
+  rowTotal.className = 'weekly-row-total';
+  rowTotal.setAttribute('data-weekly-row-total', issue.key);
+  rowTotal.textContent = '0h';
+  row.appendChild(rowTotal);
+
+  const actionCell = document.createElement('td');
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'weekly-log-btn';
+  button.setAttribute('data-weekly-issue-id', issue.key);
+  button.textContent = 'Log';
+  button.addEventListener('click', logWeeklyIssueClick);
+  actionCell.appendChild(button);
+  row.appendChild(actionCell);
+
+  return row;
+}
+
+function applyWeeklyWorklogTotals(totals: WeeklyWorklogTotals) {
+  const table = document.getElementById('weekly-log-table');
+  if (!table) return;
+
+  table.querySelectorAll<HTMLElement>('.weekly-logged-time').forEach((cell) => {
+    const issueId = cell.getAttribute('data-weekly-logged-issue-id') || '';
+    const date = cell.getAttribute('data-weekly-logged-date') || '';
+    const seconds = totals[issueId]?.[date] || 0;
+    cell.setAttribute('data-weekly-logged-seconds', String(seconds));
+    cell.textContent = seconds > 0 ? `Logged ${formatInputTotal(seconds)}` : '';
+  });
+
+  updateWeeklyTotals();
+}
+
+function addLoggedWeeklyEntriesToRow(
+  row: HTMLTableRowElement,
+  entries: WeeklyEntry[]
+) {
+  entries.forEach((entry) => {
+    const loggedTime = row.querySelector<HTMLElement>(
+      `.weekly-logged-time[data-weekly-logged-date="${entry.date}"]`
+    );
+    if (!loggedTime) return;
+
+    const previousSeconds = Number(
+      loggedTime.getAttribute('data-weekly-logged-seconds') || '0'
+    );
+    const nextSeconds =
+      (Number.isFinite(previousSeconds) ? previousSeconds : 0) + entry.seconds;
+    loggedTime.setAttribute('data-weekly-logged-seconds', String(nextSeconds));
+    loggedTime.textContent =
+      nextSeconds > 0 ? `Logged ${formatInputTotal(nextSeconds)}` : '';
+  });
+}
+
+function clearWeeklyEntryInputs(row: HTMLTableRowElement, date: string) {
+  row
+    .querySelectorAll<
+      HTMLInputElement | HTMLTextAreaElement
+    >(`[data-weekly-date="${date}"]`)
+    .forEach((input) => {
+      input.value = '';
+    });
+}
+
+function addLoggedSecondsToTableIssueTotal(issueId: string, seconds: number) {
+  const totalTime = document.querySelector<HTMLDivElement>(
+    `div.issue-total-time-spent[data-issue-id="${issueId}"]`
+  );
+  const loader = totalTime?.previousElementSibling as HTMLDivElement | null;
+  const issue = currentIssuesResponse?.data?.find(
+    (currentIssue) => currentIssue.key === issueId
+  );
+  const currentSeconds = issue
+    ? getIssueTotalSeconds(issue)
+    : parseFloat(totalTime?.textContent || '') * 3600;
+  const nextSeconds =
+    (Number.isFinite(currentSeconds) ? currentSeconds : 0) + seconds;
+
+  if (issue) {
+    issue.fields.timespent = nextSeconds;
+  }
+
+  if (loader) loader.style.display = 'none';
+  if (totalTime) {
+    totalTime.innerText = `${(nextSeconds / 3600).toFixed(1)} hrs`;
+    totalTime.style.display = 'block';
+  }
+}
+
+function updateWeeklyTotals() {
+  const table = document.getElementById('weekly-log-table');
+  if (!table) return;
+
+  const dayTotals = new Map<string, number>();
+  let grandTotal = 0;
+
+  table
+    .querySelectorAll<HTMLTableRowElement>('.weekly-issue-row')
+    .forEach((row) => {
+      let rowSeconds = 0;
+      row
+        .querySelectorAll<HTMLElement>('.weekly-logged-time')
+        .forEach((loggedTime) => {
+          const seconds = Number(
+            loggedTime.getAttribute('data-weekly-logged-seconds') || '0'
+          );
+          const date = loggedTime.getAttribute('data-weekly-logged-date') || '';
+          if (!Number.isFinite(seconds) || seconds <= 0) return;
+
+          rowSeconds += seconds;
+          dayTotals.set(date, (dayTotals.get(date) || 0) + seconds);
+        });
+
+      row
+        .querySelectorAll<HTMLInputElement>('.weekly-time-input')
+        .forEach((input) => {
+          const duration = input.value.trim();
+          if (
+            !duration ||
+            !isValidWorklogDuration(duration, { allowWeeks: true })
+          ) {
+            return;
+          }
+
+          const seconds = parseWorklogDurationToSeconds(duration, {
+            allowWeeks: true,
+          });
+          const date = input.getAttribute('data-weekly-date') || '';
+          rowSeconds += seconds;
+          dayTotals.set(date, (dayTotals.get(date) || 0) + seconds);
+        });
+
+      const rowTotal = row.querySelector<HTMLElement>('.weekly-row-total');
+      if (rowTotal) rowTotal.textContent = formatInputTotal(rowSeconds);
+      grandTotal += rowSeconds;
+    });
+
+  table
+    .querySelectorAll<HTMLElement>('[data-weekly-total-date]')
+    .forEach((cell) => {
+      const date = cell.getAttribute('data-weekly-total-date') || '';
+      cell.textContent = formatInputTotal(dayTotals.get(date) || 0);
+    });
+
+  const grandTotalCell = table.querySelector<HTMLElement>(
+    '.weekly-grand-total'
+  );
+  if (grandTotalCell) {
+    grandTotalCell.textContent = formatInputTotal(grandTotal);
+  }
+}
+
+function getWeeklyEntriesForRow(row: HTMLTableRowElement): WeeklyEntry[] {
+  const entries: WeeklyEntry[] = [];
+  row
+    .querySelectorAll<HTMLInputElement>('.weekly-time-input')
+    .forEach((timeInput) => {
+      const duration = timeInput.value.trim();
+      if (!duration) return;
+
+      const date = timeInput.getAttribute('data-weekly-date') || '';
+      const commentInput = row.querySelector<HTMLTextAreaElement>(
+        `.weekly-comment-input[data-weekly-date="${date}"]`
+      );
+
+      entries.push({
+        date,
+        duration,
+        comment: commentInput?.value ?? '',
+        seconds: parseWorklogDurationToSeconds(duration, { allowWeeks: true }),
+      });
+    });
+  return entries;
+}
+
+async function logWeeklyIssueClick(evt: Event) {
+  clearMessages();
+
+  const button = evt.currentTarget as HTMLButtonElement | null;
+  const issueId = button?.getAttribute('data-weekly-issue-id');
+  const row = issueId
+    ? document.querySelector<HTMLTableRowElement>(
+        `tr[data-weekly-issue-id="${issueId}"]`
+      )
+    : null;
+
+  if (!button || !issueId || !row) return;
+
+  const entries = getWeeklyEntriesForRow(row);
+  if (entries.length === 0) {
+    displayError(`Enter at least one time value for ${issueId}.`);
+    return;
+  }
+
+  for (const entry of entries) {
+    if (!entry.date) {
+      displayError(`Missing a worklog date for ${issueId}.`);
+      return;
+    }
+
+    if (!isValidWorklogDuration(entry.duration, { allowWeeks: true })) {
+      displayError(
+        `${issueId} on ${entry.date}: ${getWorklogDurationValidationMessage({
+          allowWeeks: true,
+        })}`
+      );
+      return;
+    }
+
+    if (isNaN(entry.seconds) || entry.seconds <= 0) {
+      displayError(
+        `Enter a positive time value for ${issueId} on ${entry.date}.`
+      );
+      return;
+    }
+  }
+
+  button.disabled = true;
+  const originalLabel = button.textContent || 'Log';
+  button.textContent = '...';
+
+  try {
+    const options = currentPopupOptions ?? (await getStoredPopupOptions());
+    const JIRA = await getSharedJira(options);
+    const postedEntries: WeeklyEntry[] = [];
+
+    for (const entry of entries) {
+      await JIRA.updateWorklog(
+        issueId,
+        entry.seconds,
+        buildWorklogStartedTimestamp(entry.date),
+        entry.comment
+      );
+
+      postedEntries.push(entry);
+      clearWeeklyEntryInputs(row, entry.date);
+      addLoggedWeeklyEntriesToRow(row, [entry]);
+      addLoggedSecondsToTableIssueTotal(issueId, entry.seconds);
+      clearWeeklyWorklogCaches();
+      updateWeeklyTotals();
+    }
+
+    const totalSeconds = postedEntries.reduce(
+      (sum, entry) => sum + entry.seconds,
+      0
+    );
+    displaySuccess(
+      `Logged ${formatInputTotal(totalSeconds)} across ${
+        postedEntries.length
+      } day${postedEntries.length === 1 ? '' : 's'} for ${issueId}.`
+    );
+    showWeeklyRowAnimation(row, true);
+  } catch (error) {
+    window.JiraErrorHandler?.handleJiraError(
+      error,
+      `Failed to log weekly time for issue ${issueId}`,
+      'popup'
+    );
+    showWeeklyRowAnimation(row, false);
+  } finally {
+    button.disabled = false;
+    button.textContent = originalLabel;
+  }
+}
+
+function showWeeklyRowAnimation(row: HTMLTableRowElement, success: boolean) {
+  row.classList.add(success ? 'success-highlight' : 'error-highlight');
+
+  setTimeout(() => {
+    row.classList.add('fade-highlight');
+    row.classList.remove(success ? 'success-highlight' : 'error-highlight');
+  }, 4000);
+
+  setTimeout(() => {
+    row.classList.remove('fade-highlight');
+  }, 5000);
+}
+
+function getStoredPopupOptions(): Promise<PopupOptions> {
+  return new Promise<PopupOptions>((resolve, reject) =>
+    chrome.storage.sync.get(
+      ['baseUrl', 'apiToken', 'jql', 'username', 'jiraType'],
+      (items) => {
+        if (chrome.runtime.lastError) {
+          return reject(chrome.runtime.lastError);
+        }
+        resolve(items as unknown as PopupOptions);
+      }
+    )
+  );
+}
+
+// ⭐️ utility function that sorts starred issues to top
 function sortIssues(
   issues: JiraIssue[],
   starredIssues: Record<string, number>,

--- a/src/ts/shared/jira-api.ts
+++ b/src/ts/shared/jira-api.ts
@@ -51,6 +51,11 @@ interface ApiPickerSection {
   issues?: ApiPickerIssue[];
 }
 
+interface ApiWorklogResponse extends JiraWorklogResponse {
+  startAt?: number;
+  maxResults?: number;
+}
+
 async function JiraAPI(
   jiraType: JiraType,
   baseUrl: string,
@@ -301,7 +306,42 @@ async function JiraAPI(
   }
 
   async function getIssueWorklog(id: string): Promise<JiraWorklogResponse> {
-    return apiRequest<JiraWorklogResponse>(`/issue/${id}/worklog`);
+    const pageSize = 100;
+    let startAt = 0;
+    let allWorklogs: JiraWorklogResponse['worklogs'] = [];
+    let total: number | null = null;
+    let firstResponse: ApiWorklogResponse | null = null;
+
+    while (true) {
+      const response = await apiRequest<ApiWorklogResponse>(
+        `/issue/${id}/worklog?startAt=${startAt}&maxResults=${pageSize}`
+      );
+      if (!firstResponse) firstResponse = response;
+
+      const worklogs = Array.isArray(response.worklogs)
+        ? response.worklogs
+        : [];
+      allWorklogs = allWorklogs.concat(worklogs);
+
+      if (typeof response.total === 'number') {
+        total = response.total;
+      }
+
+      if (
+        worklogs.length === 0 ||
+        (typeof total === 'number' && allWorklogs.length >= total)
+      ) {
+        break;
+      }
+
+      startAt += worklogs.length;
+    }
+
+    return {
+      ...(firstResponse || { worklogs: [] }),
+      worklogs: allWorklogs,
+      total: total ?? allWorklogs.length,
+    };
   }
 
   async function getProjects(begin = 0): Promise<JiraProjectsResponse> {
@@ -350,8 +390,14 @@ async function JiraAPI(
     // Invalidate cached worklog for this issue
     try {
       const url = buildAbsoluteUrl(`/issue/${id}/worklog`);
+      const worklogCachePrefix = getCacheKey(url);
       const key = getCacheKey(url);
       memoryCache.delete(key);
+      for (const cacheKey of memoryCache.keys()) {
+        if (cacheKey.startsWith(worklogCachePrefix)) {
+          memoryCache.delete(cacheKey);
+        }
+      }
       await storageLocalRemove(key);
     } catch (e: unknown) {
       console.warn('Failed to invalidate worklog cache', e);

--- a/src/ts/shared/theme-sync.ts
+++ b/src/ts/shared/theme-sync.ts
@@ -39,6 +39,7 @@ function applyDarkMode(
   toggle?: HTMLButtonElement | null
 ): void {
   updateStandardThemeToggle(toggle, isDark);
+  document.documentElement.classList.toggle('dark-mode', isDark);
   document.body.classList.toggle('dark-mode', isDark);
 }
 

--- a/src/ts/shared/types.ts
+++ b/src/ts/shared/types.ts
@@ -171,6 +171,7 @@ export interface PopupOptions extends BaseExtensionOptions {
   jql: string;
   starredIssues: Record<string, number>;
   defaultPage: string;
+  timeEntryView: 'table' | 'week';
   timeTableColumns: PopupColumnVisibility;
   timeTableColumnOrder: string[];
   timeTableSort: TimeTableSort;


### PR DESCRIPTION
## Summary

Adds a weekly calendar-style time entry view to the popup while preserving the existing table view. The Week view can be enabled from Time Table Settings, persists across popup reopen, lazily loads historical issues with work logged in the selected week, and displays existing logged time per day before adding new worklogs.

## Details

- Adds a Week view with Monday-Sunday columns, week navigation, daily totals, row totals, and per-issue Log actions.
- Moves the Table/Week setting into the Time Table Settings modal and persists it through chrome.storage.sync.
- Loads closed/historical issues for a selected week via worklog JQL only when the Week view is opened for that week.
- Fetches and buckets existing worklogs by issue/date so previous logged time appears in the calendar.
- Paginates Jira worklog fetches to avoid missing older worklogs.
- Updates root theme handling so the popup root background follows dark mode.
- Keeps the latest timetable sort setting from master and applies sorting consistently.

## Validation

- npm run typecheck
- npm run lint
- npm run build
- Prettier checks on touched files
- git diff --cached --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Jira worklog POST paths and heavier per-issue worklog fetching in week view increase API load and surface area for auth/JQL edge cases, though behavior mirrors existing table logging.
> 
> **Overview**
> Adds an optional **weekly calendar view** alongside the existing table, toggled via **Weekly calendar view** in Time Table Settings and persisted as `timeEntryView` in `chrome.storage.sync`.
> 
> The week UI includes Mon–Sun columns, prev/next/today navigation, per-day and row totals, and per-issue **Log** actions that can post multiple days in one click. When week view is active, the popup merges the main JQL issue list with a lazy **worklogAuthor / worklogDate** JQL fetch so issues you logged that week still appear, then loads per-issue worklogs (with in-memory caching) to show **already logged** time per cell before new entries.
> 
> **`getIssueWorklog`** now paginates with `startAt`/`maxResults` and clears paginated worklog cache keys after updates. Gear buttons are shared via `.gear-btn` (table header + week toolbar). Dark mode applies `dark-mode` on `html` and sets root background colors for the popup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f335928ebd63a2253e7f4b745f8b7696f41973f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->