### PR TITLE
Fix CLI nav button alignment

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -114,6 +114,11 @@
         display: block;
       }
 
+      #nav > .theme-button {
+        display: inline-flex;
+        text-decoration: none;
+      }
+
       a {
         color: #0052cc;
         text-decoration: none;
@@ -489,6 +494,7 @@
       .caret-button:focus,
       .caret-button:focus-visible {
         outline: none;
+        text-decoration: none;
         background: linear-gradient(
           135deg,
           #4fd1ff 0%,
@@ -526,6 +532,7 @@
 
       /* Fine-tune caret button centering */
       .caret-button .icon {
+        font-family: Arial, Helvetica, sans-serif;
         font-size: 18px;
         transform: translateY(-1px);
       }

--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -154,6 +154,11 @@
         display: block;
       }
 
+      #nav > .theme-button {
+        display: inline-flex;
+        text-decoration: none;
+      }
+
       /* ===== Table Styles ===== */
       th {
         font-size: 11px;
@@ -781,6 +786,7 @@
       .caret-button:focus,
       .caret-button:focus-visible {
         outline: none;
+        text-decoration: none;
         background: linear-gradient(
           135deg,
           #4fd1ff 0%,
@@ -828,6 +834,7 @@
 
       /* Fine-tune caret button centering */
       .caret-button .icon {
+        font-family: Arial, Helvetica, sans-serif;
         font-size: 18px;
         transform: translateY(-1px);
       }

--- a/src/html/search.html
+++ b/src/html/search.html
@@ -358,6 +358,11 @@
         display: block;
       }
 
+      #nav > .theme-button {
+        display: inline-flex;
+        text-decoration: none;
+      }
+
       .theme-toggle {
         display: inline-flex;
         align-items: center;
@@ -589,6 +594,7 @@
       .caret-button:focus,
       .caret-button:focus-visible {
         outline: none;
+        text-decoration: none;
         background: linear-gradient(
           135deg,
           #4fd1ff 0%,
@@ -636,6 +642,7 @@
 
       /* Fine-tune caret button centering */
       .caret-button .icon {
+        font-family: Arial, Helvetica, sans-serif;
         font-size: 18px;
         transform: translateY(-1px);
       }

--- a/src/html/timerFeatureModule/timer.html
+++ b/src/html/timerFeatureModule/timer.html
@@ -388,6 +388,11 @@
         display: block;
       }
 
+      #nav > .theme-button {
+        display: inline-flex;
+        text-decoration: none;
+      }
+
       /* Simple, minimal theme button with just the emoji - now a rounded square */
       .theme-button {
         display: inline-flex;
@@ -422,6 +427,7 @@
       .caret-button:focus,
       .caret-button:focus-visible {
         outline: none;
+        text-decoration: none;
         background: linear-gradient(
           135deg,
           #4fd1ff 0%,
@@ -460,6 +466,7 @@
 
       /* Fine-tune caret button centering */
       .caret-button .icon {
+        font-family: Arial, Helvetica, sans-serif;
         font-size: 18px;
         transform: translateY(-1px);
       }


### PR DESCRIPTION
## Summary

Fixes the Open CLI nav button so its glyph stays horizontally centered within the button and does not pick up the global link underline on hover/focus.

## Root cause

The shared `#nav > * { display: inline-block; }` rule was overriding `.theme-button`'s intended `inline-flex` centering when the CLI button is rendered as an anchor. The same anchor also inherited the global `a:hover` / `a:focus` underline behavior.

## Changes

- Restore `inline-flex` display for `.theme-button` elements inside the nav.
- Suppress text decoration for the CLI-style theme button and its hover/focus states.
- Use a regular text font for the CLI glyph to make centering more predictable.

## Validation

- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only nav presentation tweaks with no logic, auth, or data changes.
> 
> **Overview**
> Fixes **Open CLI** footer nav styling when it is rendered as an anchor with `theme-button` / `caret-button` classes.
> 
> Adds `#nav > .theme-button` rules so those controls keep **`inline-flex`** and **no underline**, overriding the shared `#nav > * { display: inline-block }` rule and global link hover/focus underlines. The caret glyph uses **Arial/Helvetica** instead of the emoji icon stack, and hover/focus on `.caret-button` explicitly sets **`text-decoration: none`**.
> 
> The same CSS block is applied in **options**, **popup**, **search**, and **timer** pages so the bottom nav stays consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e46be766ef26ea11f209318224e319a205fa38e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->