### PR TITLE
Update weekly worklog comment placeholder

### DIFF
--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -1639,7 +1639,7 @@ function generateWeeklyIssueRow(
 
     const commentInput = document.createElement('textarea');
     commentInput.className = 'weekly-comment-input';
-    commentInput.placeholder = 'Comment';
+    commentInput.placeholder = 'Worklog comment';
     commentInput.setAttribute('data-weekly-issue-id', issue.key);
     commentInput.setAttribute('data-weekly-date', dateValue);
 


### PR DESCRIPTION
## Summary

Updates the weekly calendar view comment field placeholder from `Comment` to `Worklog comment` so it matches the requested wording and the rest of the worklog UI language.

## Impact

Users see clearer placeholder text when entering worklog comments in the calendar view.

## Validation

- `npm run build`
- `npm run typecheck`
