### PR TITLE
Add statistics tab

### DIFF
--- a/src/html/popup.html
+++ b/src/html/popup.html
@@ -14,6 +14,11 @@
         background-color: #ffffff;
       }
 
+      html.compact-popup-view {
+        height: auto;
+        min-height: 370px;
+      }
+
       /* Toolbar popup: overall width 750px (border-box; no extra px from side padding). */
       body {
         margin: 0;
@@ -23,6 +28,10 @@
         padding: 0;
         min-height: 100%;
         background-color: #ffffff;
+      }
+
+      html.compact-popup-view body {
+        min-height: 370px;
       }
 
       /* Experimental + Page View: fluid width up to 1400px (same as full-tab pages). */
@@ -671,25 +680,70 @@
         padding-bottom: 50px;
       }
 
+      html.compact-popup-view #table-container {
+        padding-bottom: 24px;
+      }
+
       .view-toolbar {
         display: none;
+        grid-template-columns: auto 1fr auto;
         align-items: center;
-        justify-content: flex-end;
         gap: 6px;
         padding: 6px 0 4px;
         margin: 0 3px;
+      }
+
+      .view-tabs {
+        display: inline-flex;
+        align-items: center;
+        gap: 2px;
+        border: 1px solid #c8d4e5;
+        border-radius: 4px;
+        background: #f8fafc;
+        padding: 2px;
+      }
+
+      .view-tab-btn {
+        width: auto;
+        min-width: 52px;
+        border: none;
+        background: transparent;
+        color: #253858;
+        border-radius: 3px;
+        cursor: pointer;
+        font-size: 12px;
+        line-height: 1;
+        padding: 5px 8px;
+      }
+
+      .view-tab-btn:hover {
+        background: #eef4ff;
+      }
+
+      .view-tab-btn.active {
+        background: #0052cc;
+        color: #fff;
       }
 
       .week-controls {
         display: none;
         align-items: center;
         gap: 4px;
-        margin-left: auto;
+        justify-self: end;
+      }
+
+      .toolbar-settings {
+        display: flex;
+        align-items: center;
+        justify-content: flex-end;
+        min-width: 24px;
       }
 
       .week-nav-btn,
       #week-today-btn {
         width: auto;
+        height: 24px;
+        box-sizing: border-box;
         border: 1px solid #c8d4e5;
         background: #fff;
         color: #253858;
@@ -710,16 +764,6 @@
         border-color: #0052cc;
       }
 
-      .week-settings-btn {
-        margin-left: 4px;
-        border: 1px solid #c8d4e5;
-        background: #fff;
-      }
-
-      .week-settings-btn:hover {
-        border-color: #0052cc;
-      }
-
       #week-range-label {
         min-width: 128px;
         text-align: center;
@@ -732,6 +776,116 @@
         display: none;
         overflow-x: auto;
         padding-bottom: 8px;
+      }
+
+      #stats-view {
+        display: none;
+        padding: 4px 3px 12px;
+      }
+
+      .stats-summary {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 6px;
+        margin-bottom: 8px;
+      }
+
+      .stats-card,
+      .stats-section {
+        border: 1px solid #dfe1e6;
+        border-radius: 6px;
+        background: #fff;
+      }
+
+      .stats-card {
+        padding: 8px;
+      }
+
+      .stats-label {
+        color: #5e6c84;
+        font-size: 10px;
+        line-height: 1.2;
+        margin-bottom: 4px;
+      }
+
+      .stats-value {
+        color: #172b4d;
+        font-size: 18px;
+        font-weight: bold;
+        line-height: 1.1;
+      }
+
+      .stats-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+
+      .stats-section {
+        padding: 10px;
+      }
+
+      .stats-section-title {
+        color: #172b4d;
+        font-size: 12px;
+        font-weight: bold;
+        margin-bottom: 8px;
+      }
+
+      .stats-bar-row {
+        display: grid;
+        grid-template-columns: 54px minmax(0, 1fr) 46px;
+        align-items: center;
+        gap: 8px;
+        min-height: 24px;
+        font-size: 11px;
+      }
+
+      .stats-bar-track {
+        height: 8px;
+        background: #ebecf0;
+        border-radius: 4px;
+        overflow: hidden;
+      }
+
+      .stats-bar-fill {
+        height: 100%;
+        min-width: 2px;
+        background: #36b37e;
+        border-radius: 4px;
+      }
+
+      .stats-issue-row {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 52px;
+        align-items: center;
+        gap: 8px;
+        min-height: 28px;
+        border-top: 1px solid #f1f2f4;
+        font-size: 11px;
+      }
+
+      .stats-issue-row:first-child {
+        border-top: none;
+      }
+
+      .stats-issue-link {
+        font-weight: bold;
+      }
+
+      .stats-issue-summary {
+        color: #5e6c84;
+        font-size: 10px;
+        margin-top: 2px;
+      }
+
+      .stats-empty {
+        padding: 20px;
+        text-align: center;
+        color: #5e6c84;
+        border: 1px solid #dfe1e6;
+        border-radius: 6px;
+        background: #fff;
       }
 
       #weekly-log-table {
@@ -1008,7 +1162,8 @@
 
       body.dark-mode .week-nav-btn,
       body.dark-mode #week-today-btn,
-      body.dark-mode .week-settings-btn {
+      body.dark-mode .week-settings-btn,
+      body.dark-mode .view-tabs {
         background: #1a1a1a;
         border-color: #333;
         color: #e0e0e0;
@@ -1016,16 +1171,53 @@
 
       body.dark-mode .week-nav-btn:hover,
       body.dark-mode #week-today-btn:hover,
-      body.dark-mode .week-settings-btn:hover {
+      body.dark-mode .week-settings-btn:hover,
+      body.dark-mode .view-tab-btn:hover {
         background: #252525;
         border-color: #4690dd;
+      }
+
+      body.dark-mode .view-tab-btn {
+        color: #e0e0e0;
+      }
+
+      body.dark-mode .view-tab-btn.active {
+        background: #4690dd;
+        color: #1a1a1a;
       }
 
       body.dark-mode #week-range-label,
       body.dark-mode .weekly-issue-summary,
       body.dark-mode .weekly-date-label,
-      body.dark-mode .weekly-empty {
+      body.dark-mode .weekly-empty,
+      body.dark-mode .stats-label,
+      body.dark-mode .stats-issue-summary,
+      body.dark-mode .stats-empty {
         color: #aaa;
+      }
+
+      body.dark-mode .stats-card,
+      body.dark-mode .stats-section,
+      body.dark-mode .stats-empty {
+        background: #1a1a1a;
+        border-color: #333;
+      }
+
+      body.dark-mode .stats-value,
+      body.dark-mode .stats-section-title {
+        color: #e0e0e0;
+      }
+
+      body.dark-mode .stats-bar-track {
+        background: #252525;
+      }
+
+      body.dark-mode .stats-bar-fill {
+        background: #90ee90;
+      }
+
+      body.dark-mode .stats-issue-row {
+        border-top-color: #333;
       }
 
       body.dark-mode .weekly-log-btn {
@@ -1138,19 +1330,21 @@
         background-color: rgba(46, 139, 87, 0.5);
       }
 
-      /* ===== Gear button inside actions header cell ===== */
+      /* ===== Gear settings button ===== */
       .gear-btn {
         display: inline-flex;
         align-items: center;
         justify-content: center;
         width: 22px;
         height: 22px;
+        box-sizing: border-box;
         border-radius: 4px;
         cursor: pointer;
         border: none;
         padding: 0;
         background: transparent;
         color: #0052cc;
+        line-height: 0;
         vertical-align: middle;
       }
       .gear-btn:hover {
@@ -1166,6 +1360,30 @@
       body.dark-mode .gear-btn:hover {
         background: rgba(70, 144, 221, 0.2);
         color: #7eb4f0;
+      }
+
+      .toolbar-settings .gear-btn {
+        width: auto;
+        min-width: 26px;
+        height: 24px;
+        border: 1px solid #c8d4e5;
+        background: #fff;
+        color: #0052cc;
+      }
+
+      .toolbar-settings .gear-btn:hover {
+        background: #eef4ff;
+        border-color: #0052cc;
+      }
+
+      body.dark-mode .toolbar-settings .gear-btn {
+        background: #1a1a1a;
+        border-color: #333;
+      }
+
+      body.dark-mode .toolbar-settings .gear-btn:hover {
+        background: #252525;
+        border-color: #4690dd;
       }
 
       /* Column-specific padding for compact columns */
@@ -1526,6 +1744,32 @@
     <div id="success"></div>
     <div id="table-container">
       <div class="view-toolbar">
+        <div class="view-tabs" role="tablist" aria-label="Time views">
+          <button
+            class="view-tab-btn"
+            type="button"
+            data-time-entry-view="table"
+            role="tab"
+          >
+            Table
+          </button>
+          <button
+            class="view-tab-btn"
+            type="button"
+            data-time-entry-view="week"
+            role="tab"
+          >
+            Week
+          </button>
+          <button
+            class="view-tab-btn"
+            type="button"
+            data-time-entry-view="stats"
+            role="tab"
+          >
+            Stats
+          </button>
+        </div>
         <div id="week-controls" class="week-controls">
           <button
             id="week-prev-btn"
@@ -1548,6 +1792,7 @@
             ›
           </button>
         </div>
+        <div id="toolbar-settings" class="toolbar-settings"></div>
       </div>
       <div id="table-view">
         <table id="jira-log-time-table">
@@ -1563,6 +1808,9 @@
           <tbody></tbody>
           <tfoot></tfoot>
         </table>
+      </div>
+      <div id="stats-view">
+        <div id="stats-content"></div>
       </div>
       <div id="loader-container">
         <div class="loader"></div>
@@ -1641,9 +1889,16 @@
           <div class="gear-section">
             <div class="gear-section-title">View</div>
             <div class="gear-toggle-row">
-              <label for="gear-week-view-toggle">
-                <span>Weekly calendar view</span>
-                <input id="gear-week-view-toggle" type="checkbox" />
+              <label for="gear-time-entry-view-select">
+                <span>Default view</span>
+                <select
+                  id="gear-time-entry-view-select"
+                  aria-label="Default popup view"
+                >
+                  <option value="table">Table</option>
+                  <option value="week">Week</option>
+                  <option value="stats">Stats</option>
+                </select>
               </label>
             </div>
           </div>

--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -27,7 +27,7 @@ type CachedIssuesResponse = {
   ts: number;
 };
 
-type TimeEntryView = 'table' | 'week';
+type TimeEntryView = PopupOptions['timeEntryView'];
 
 type WeeklyEntry = {
   date: string;
@@ -43,6 +43,11 @@ type WeeklyLoggedIssuesCacheEntry = {
 
 type WeeklyWorklogTotals = Record<string, Record<string, number>>;
 
+type StatsIssueTotal = {
+  issue: JiraIssue;
+  seconds: number;
+};
+
 type WeeklyWorklogTotalsCacheEntry = {
   data: WeeklyWorklogTotals;
   ts: number;
@@ -52,7 +57,7 @@ const WEEKDAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const WEEKLY_LOGGED_ISSUES_CACHE_TTL_MS = 5 * 60 * 1000;
 const WEEKLY_WORKLOG_TOTALS_CACHE_TTL_MS = 60 * 1000;
 const GEAR_ICON_SVG =
-  '<svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor"><path d="M6.5.5a.5.5 0 0 0-.5.5v1.07a5.5 5.5 0 0 0-1.56.64L3.7 1.97a.5.5 0 0 0-.7 0l-.71.7a.5.5 0 0 0 0 .71l.74.74A5.5 5.5 0 0 0 2.4 5.7H1.3a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1.1a5.5 5.5 0 0 0 .63 1.58l-.74.74a.5.5 0 0 0 0 .7l.71.71a.5.5 0 0 0 .7 0l.74-.74a5.5 5.5 0 0 0 1.56.64V12.5a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1.07a5.5 5.5 0 0 0 1.56-.64l.74.74a.5.5 0 0 0 .7 0l.71-.7a.5.5 0 0 0 0-.71l-.74-.74A5.5 5.5 0 0 0 11.6 7.7h1.1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5h-1.1a5.5 5.5 0 0 0-.63-1.58l.74-.74a.5.5 0 0 0 0-.7l-.71-.71a.5.5 0 0 0-.7 0l-.74.74A5.5 5.5 0 0 0 8 2.07V1a.5.5 0 0 0-.5-.5h-1zM7 4.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5z"/></svg>';
+  '<svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor"><path d="M6.5.5a.5.5 0 0 0-.5.5v1.07a5.5 5.5 0 0 0-1.56.64L3.7 1.97a.5.5 0 0 0-.7 0l-.71.7a.5.5 0 0 0 0 .71l.74.74A5.5 5.5 0 0 0 2.4 5.7H1.3a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h1.1a5.5 5.5 0 0 0 .63 1.58l-.74.74a.5.5 0 0 0 0 .7l.71.71a.5.5 0 0 0 .7 0l.74-.74a5.5 5.5 0 0 0 1.56.64V12.5a.5.5 0 0 0 .5.5h1a.5.5 0 0 0 .5-.5v-1.07a5.5 5.5 0 0 0 1.56-.64l.74.74a.5.5 0 0 0 .7 0l.71-.7a.5.5 0 0 0 0-.71l-.74-.74A5.5 5.5 0 0 0 11.6 7.7h1.1a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5h-1.1a5.5 5.5 0 0 0-.63-1.58l.74-.74a.5.5 0 0 0 0-.7l-.71-.71a.5.5 0 0 0-.7 0l-.74.74A5.5 5.5 0 0 0 8 2.07V1a.5.5 0 0 0-.5-.5h-1zM7 4.5a2.5 2.5 0 1 1 0 5 2.5 2.5 0 0 1 0-5z"/></svg>';
 
 let activeTimeEntryView: TimeEntryView = 'table';
 let currentWeekStart = getStartOfWeek(new Date());
@@ -470,7 +475,10 @@ function initViewControls() {
   if (viewControlsInitialized) return;
   viewControlsInitialized = true;
 
-  const weekControls = document.getElementById('week-controls');
+  const toolbarSettings = document.getElementById('toolbar-settings');
+  const viewButtons = document.querySelectorAll<HTMLButtonElement>(
+    '[data-time-entry-view]'
+  );
   const prevBtn = document.getElementById(
     'week-prev-btn'
   ) as HTMLButtonElement | null;
@@ -483,46 +491,82 @@ function initViewControls() {
 
   prevBtn?.addEventListener('click', () => {
     currentWeekStart = addDays(currentWeekStart, -7);
-    void renderCurrentWeeklyView();
+    void renderActiveTimeEntryView();
   });
   nextBtn?.addEventListener('click', () => {
     currentWeekStart = addDays(currentWeekStart, 7);
-    void renderCurrentWeeklyView();
+    void renderActiveTimeEntryView();
   });
   todayBtn?.addEventListener('click', () => {
     currentWeekStart = getStartOfWeek(new Date());
-    void renderCurrentWeeklyView();
+    void renderActiveTimeEntryView();
+  });
+  viewButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const view = button.getAttribute('data-time-entry-view');
+      if (!isTimeEntryView(view)) return;
+
+      setTimeEntryView(view);
+      if (currentPopupOptions) {
+        currentPopupOptions.timeEntryView = view;
+      }
+      chrome.storage.sync.set({ timeEntryView: view });
+    });
   });
 
-  if (weekControls && !document.getElementById('week-gear-btn')) {
-    const weekGearBtn = buildGearButton();
-    weekGearBtn.id = 'week-gear-btn';
-    weekGearBtn.classList.add('week-settings-btn');
-    weekControls.appendChild(weekGearBtn);
+  if (toolbarSettings && !document.getElementById('toolbar-gear-btn')) {
+    const toolbarGearBtn = buildGearButton();
+    toolbarGearBtn.id = 'toolbar-gear-btn';
+    toolbarSettings.appendChild(toolbarGearBtn);
   }
 
   setTimeEntryView(activeTimeEntryView);
 }
 
+function renderActiveTimeEntryView() {
+  if (activeTimeEntryView === 'week') {
+    return renderCurrentWeeklyView();
+  }
+
+  if (activeTimeEntryView === 'stats') {
+    return renderCurrentStatsView();
+  }
+
+  updateWeekRangeLabel();
+  return Promise.resolve();
+}
+
 function setTimeEntryView(view: TimeEntryView) {
   activeTimeEntryView = view;
+  document.documentElement.classList.toggle(
+    'compact-popup-view',
+    view === 'stats'
+  );
 
   const viewToolbar = document.querySelector<HTMLElement>('.view-toolbar');
   const tableView = document.getElementById('table-view');
   const weekView = document.getElementById('week-view');
+  const statsView = document.getElementById('stats-view');
   const weekControls = document.getElementById('week-controls');
 
   if (tableView) tableView.style.display = view === 'table' ? 'block' : 'none';
   if (weekView) weekView.style.display = view === 'week' ? 'block' : 'none';
-  if (viewToolbar)
-    viewToolbar.style.display = view === 'week' ? 'flex' : 'none';
+  if (statsView) statsView.style.display = view === 'stats' ? 'block' : 'none';
+  if (viewToolbar) viewToolbar.style.display = 'grid';
   if (weekControls) {
-    weekControls.style.display = view === 'week' ? 'flex' : 'none';
+    weekControls.style.display =
+      view === 'week' || view === 'stats' ? 'flex' : 'none';
   }
 
-  if (view === 'week') {
-    void renderCurrentWeeklyView();
-  }
+  document
+    .querySelectorAll<HTMLButtonElement>('[data-time-entry-view]')
+    .forEach((button) => {
+      const isActive = button.getAttribute('data-time-entry-view') === view;
+      button.classList.toggle('active', isActive);
+      button.setAttribute('aria-selected', String(isActive));
+    });
+
+  void renderActiveTimeEntryView();
 }
 
 async function renderCurrentWeeklyView() {
@@ -588,6 +632,83 @@ async function renderCurrentWeeklyView() {
       window.JiraErrorHandler?.handleJiraError(
         error,
         'Failed to load issues with work logged for this week',
+        'popup'
+      );
+    }
+  }
+}
+
+async function renderCurrentStatsView() {
+  updateWeekRangeLabel();
+
+  if (!currentIssuesResponse || !currentPopupOptions) {
+    drawStatsView({ data: [], total: 0 }, null, null, true);
+    return;
+  }
+
+  const options = currentPopupOptions;
+  const baseIssuesResponse = currentIssuesResponse;
+  const issueVersion = currentIssuesResponseVersion;
+  const cacheKey = getWeeklyLoggedIssuesCacheKey(options);
+
+  const loadStatsTotals = async (issuesResponse: JiraIssuesResponse) => {
+    const worklogTotalsVersion = weeklyWorklogTotalsVersion;
+    const totals = await loadWeeklyWorklogTotals(options, issuesResponse);
+    if (
+      activeTimeEntryView !== 'stats' ||
+      currentPopupOptions !== options ||
+      currentIssuesResponseVersion !== issueVersion ||
+      weeklyWorklogTotalsVersion !== worklogTotalsVersion ||
+      getWeeklyLoggedIssuesCacheKey(options) !== cacheKey
+    ) {
+      return;
+    }
+
+    drawStatsView(issuesResponse, options, totals);
+  };
+
+  const cached = weeklyLoggedIssuesCache.get(cacheKey);
+  if (cached && Date.now() - cached.ts < WEEKLY_LOGGED_ISSUES_CACHE_TTL_MS) {
+    const mergedIssuesResponse = mergeIssueResponses(
+      baseIssuesResponse,
+      cached.data
+    );
+    drawStatsView(mergedIssuesResponse, options, null, true);
+    await loadStatsTotals(mergedIssuesResponse);
+    return;
+  }
+
+  drawStatsView(baseIssuesResponse, options, null, true);
+
+  try {
+    const loggedIssuesResponse = await loadLoggedIssuesForCurrentWeek(options);
+    if (
+      activeTimeEntryView !== 'stats' ||
+      currentPopupOptions !== options ||
+      currentIssuesResponseVersion !== issueVersion ||
+      getWeeklyLoggedIssuesCacheKey(options) !== cacheKey
+    ) {
+      return;
+    }
+
+    const mergedIssuesResponse = mergeIssueResponses(
+      baseIssuesResponse,
+      loggedIssuesResponse
+    );
+    drawStatsView(mergedIssuesResponse, options, null, true);
+    await loadStatsTotals(mergedIssuesResponse);
+  } catch (error) {
+    console.warn('Failed to load statistics issues:', error);
+    if (
+      activeTimeEntryView === 'stats' &&
+      currentPopupOptions === options &&
+      currentIssuesResponseVersion === issueVersion &&
+      getWeeklyLoggedIssuesCacheKey(options) === cacheKey
+    ) {
+      drawStatsView(baseIssuesResponse, options, {});
+      window.JiraErrorHandler?.handleJiraError(
+        error,
+        'Failed to load statistics for this week',
         'popup'
       );
     }
@@ -670,8 +791,7 @@ async function onDOMContentLoaded() {
         options.timeTableColumnOrder
       );
       options.timeTableSort = normalizeTimeTableSort(options.timeTableSort);
-      options.timeEntryView =
-        options.timeEntryView === 'week' ? 'week' : 'table';
+      options.timeEntryView = normalizeTimeEntryView(options.timeEntryView);
       activeTimeEntryView = options.timeEntryView;
 
       const urlParams = new URLSearchParams(window.location.search);
@@ -702,6 +822,14 @@ async function onDOMContentLoaded() {
 
 function normalizeTimeTableSort(sort: unknown): TimeTableSort {
   return isTimeTableSort(sort) ? sort : DEFAULT_TIME_TABLE_SORT;
+}
+
+function normalizeTimeEntryView(view: unknown): TimeEntryView {
+  return isTimeEntryView(view) ? view : 'table';
+}
+
+function isTimeEntryView(view: unknown): view is TimeEntryView {
+  return view === 'table' || view === 'week' || view === 'stats';
 }
 
 function isTimeTableSort(sort: unknown): sort is TimeTableSort {
@@ -744,10 +872,10 @@ function syncGearPanelState(options: PopupOptions) {
   ) as HTMLSelectElement | null;
   if (sortSelect) sortSelect.value = options.timeTableSort;
 
-  const weekViewToggle = document.getElementById(
-    'gear-week-view-toggle'
-  ) as HTMLInputElement | null;
-  if (weekViewToggle) weekViewToggle.checked = activeTimeEntryView === 'week';
+  const viewSelect = document.getElementById(
+    'gear-time-entry-view-select'
+  ) as HTMLSelectElement | null;
+  if (viewSelect) viewSelect.value = activeTimeEntryView;
 
   renderGearColumnOrder(
     options.timeTableColumnOrder.filter(isColumnId),
@@ -793,9 +921,9 @@ function initGearPanel(options: PopupOptions) {
   const sortSelect = document.getElementById(
     'gear-time-table-sort'
   ) as HTMLSelectElement;
-  const weekViewToggle = document.getElementById(
-    'gear-week-view-toggle'
-  ) as HTMLInputElement;
+  const viewSelect = document.getElementById(
+    'gear-time-entry-view-select'
+  ) as HTMLSelectElement;
 
   syncGearPanelState(options);
 
@@ -813,7 +941,7 @@ function initGearPanel(options: PopupOptions) {
     const newCols = readGearColumnVisibility();
     const newOrder = readGearColumnOrder();
     const newSort = normalizeTimeTableSort(sortSelect.value);
-    const nextView: TimeEntryView = weekViewToggle.checked ? 'week' : 'table';
+    const nextView = normalizeTimeEntryView(viewSelect.value);
     const jqlChanged = newJql !== options.jql;
 
     options.jql = newJql;
@@ -1085,6 +1213,7 @@ function clearTimeTableRows(options: PopupOptions) {
   currentPopupOptions = options;
   drawIssuesTable(emptyResponse, options);
   drawWeeklyView(emptyResponse, options);
+  drawStatsView(emptyResponse, options, {});
 }
 
 async function clearCachedTimeTableData(options: PopupOptions) {
@@ -1218,6 +1347,8 @@ function onFetchSuccess(
   drawIssuesTable(issuesResponse, options);
   if (activeTimeEntryView === 'week') {
     void renderCurrentWeeklyView();
+  } else if (activeTimeEntryView === 'stats') {
+    void renderCurrentStatsView();
   }
 }
 
@@ -1369,6 +1500,7 @@ async function logTimeClick(evt: Event) {
 
     // Display success message with the logged time
     showSuccessAnimation(issueId, timeInput.value);
+    clearWeeklyWorklogCaches();
 
     timeInput.value = '';
     if (commentInput) commentInput.value = '';
@@ -1440,7 +1572,7 @@ function drawIssuesTable(
     if (colId === 'issueId') {
       th.innerHTML = `<img src="${chrome.runtime.getURL('src/icons/jira_logo.png')}" alt="Jira Logo" style="vertical-align:middle;margin-right:8px;width:16px;height:16px;"> Jira ID`;
     } else if (colId === 'actions') {
-      th.appendChild(buildGearButton());
+      th.textContent = '';
     } else {
       th.textContent = def.label;
     }
@@ -1497,7 +1629,7 @@ function drawWeeklyView(
   const headerRow = document.createElement('tr');
   const issueHeading = document.createElement('th');
   issueHeading.className = 'weekly-issue-heading';
-  issueHeading.textContent = 'Issue';
+  issueHeading.textContent = 'Work item';
   headerRow.appendChild(issueHeading);
 
   weekDates.forEach((date, index) => {
@@ -1592,6 +1724,190 @@ function drawWeeklyLoadingState(
   loadingCell.textContent = 'Loading logged issues for this week...';
   loadingRow.appendChild(loadingCell);
   tbody.appendChild(loadingRow);
+}
+
+function drawStatsView(
+  issuesResponse: JiraIssuesResponse,
+  options: PopupOptions | null,
+  totals: WeeklyWorklogTotals | null,
+  isLoading = false
+) {
+  const statsContent = document.getElementById('stats-content');
+  if (!statsContent) return;
+
+  statsContent.innerHTML = '';
+
+  if (isLoading || totals === null) {
+    const loading = document.createElement('div');
+    loading.className = 'stats-empty';
+    loading.textContent = 'Loading statistics for this week...';
+    statsContent.appendChild(loading);
+    return;
+  }
+
+  const weekDates = getWeekDates();
+  const dayTotals = new Map<string, number>();
+  const issueTotals: StatsIssueTotal[] = (issuesResponse.data || [])
+    .map((issue) => {
+      const seconds = Object.values(totals[issue.key] || {}).reduce(
+        (sum, issueDaySeconds) => sum + issueDaySeconds,
+        0
+      );
+      return { issue, seconds };
+    })
+    .filter((entry) => entry.seconds > 0)
+    .sort((a, b) => b.seconds - a.seconds);
+
+  weekDates.forEach((date) => {
+    const dateKey = formatWeeklyDateKey(date);
+    const seconds = Object.values(totals).reduce(
+      (sum, issueTotalsByDate) => sum + (issueTotalsByDate[dateKey] || 0),
+      0
+    );
+    dayTotals.set(dateKey, seconds);
+  });
+
+  const grandTotal = Array.from(dayTotals.values()).reduce(
+    (sum, seconds) => sum + seconds,
+    0
+  );
+  const loggedDays = Array.from(dayTotals.values()).filter(
+    (seconds) => seconds > 0
+  ).length;
+
+  if (grandTotal === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'stats-empty';
+    empty.textContent = 'No work logged this week.';
+    statsContent.appendChild(empty);
+    return;
+  }
+
+  const summary = document.createElement('div');
+  summary.className = 'stats-summary';
+  summary.appendChild(
+    createStatsCard('Total logged', formatInputTotal(grandTotal))
+  );
+  summary.appendChild(
+    createStatsCard(
+      'Daily average',
+      formatInputTotal(grandTotal / weekDates.length)
+    )
+  );
+  summary.appendChild(createStatsCard('Days logged', String(loggedDays)));
+  summary.appendChild(
+    createStatsCard('Work items touched', String(issueTotals.length))
+  );
+  statsContent.appendChild(summary);
+
+  const grid = document.createElement('div');
+  grid.className = 'stats-grid';
+  grid.appendChild(createDailyStatsSection(weekDates, dayTotals));
+  grid.appendChild(createIssueStatsSection(issueTotals, options));
+  statsContent.appendChild(grid);
+}
+
+function createStatsCard(label: string, value: string) {
+  const card = document.createElement('div');
+  card.className = 'stats-card';
+
+  const labelElement = document.createElement('div');
+  labelElement.className = 'stats-label';
+  labelElement.textContent = label;
+
+  const valueElement = document.createElement('div');
+  valueElement.className = 'stats-value';
+  valueElement.textContent = value;
+
+  card.appendChild(labelElement);
+  card.appendChild(valueElement);
+  return card;
+}
+
+function createDailyStatsSection(
+  weekDates: Date[],
+  dayTotals: Map<string, number>
+) {
+  const section = document.createElement('div');
+  section.className = 'stats-section';
+
+  const title = document.createElement('div');
+  title.className = 'stats-section-title';
+  title.textContent = 'Daily totals';
+  section.appendChild(title);
+
+  const maxSeconds = Math.max(1, ...Array.from(dayTotals.values()));
+  weekDates.forEach((date, index) => {
+    const dateKey = formatWeeklyDateKey(date);
+    const seconds = dayTotals.get(dateKey) || 0;
+    const row = document.createElement('div');
+    row.className = 'stats-bar-row';
+
+    const label = document.createElement('div');
+    label.textContent = `${WEEKDAY_LABELS[index]} ${formatShortDate(date)}`;
+
+    const track = document.createElement('div');
+    track.className = 'stats-bar-track';
+    const fill = document.createElement('div');
+    fill.className = 'stats-bar-fill';
+    fill.style.width = `${Math.max(0, (seconds / maxSeconds) * 100)}%`;
+    track.appendChild(fill);
+
+    const value = document.createElement('div');
+    value.textContent = formatInputTotal(seconds);
+
+    row.appendChild(label);
+    row.appendChild(track);
+    row.appendChild(value);
+    section.appendChild(row);
+  });
+
+  return section;
+}
+
+function createIssueStatsSection(
+  issueTotals: StatsIssueTotal[],
+  options: PopupOptions | null
+) {
+  const section = document.createElement('div');
+  section.className = 'stats-section';
+
+  const title = document.createElement('div');
+  title.className = 'stats-section-title';
+  title.textContent = 'Top work items';
+  section.appendChild(title);
+
+  issueTotals.slice(0, 5).forEach(({ issue, seconds }) => {
+    const row = document.createElement('div');
+    row.className = 'stats-issue-row';
+
+    const issueInfo = document.createElement('div');
+    const issueKey = options
+      ? document.createElement('a')
+      : document.createElement('span');
+    issueKey.className = 'stats-issue-link';
+    issueKey.textContent = issue.key;
+    if (issueKey instanceof HTMLAnchorElement && options) {
+      issueKey.href = getJiraIssueUrl(issue.key, options);
+      issueKey.target = '_blank';
+    }
+
+    const summary = document.createElement('div');
+    summary.className = 'stats-issue-summary truncate';
+    summary.textContent = issue.fields.summary ?? '';
+
+    issueInfo.appendChild(issueKey);
+    issueInfo.appendChild(summary);
+
+    const value = document.createElement('div');
+    value.textContent = formatInputTotal(seconds);
+
+    row.appendChild(issueInfo);
+    row.appendChild(value);
+    section.appendChild(row);
+  });
+
+  return section;
 }
 
 function generateWeeklyIssueRow(

--- a/src/ts/shared/types.ts
+++ b/src/ts/shared/types.ts
@@ -171,7 +171,7 @@ export interface PopupOptions extends BaseExtensionOptions {
   jql: string;
   starredIssues: Record<string, number>;
   defaultPage: string;
-  timeEntryView: 'table' | 'week';
+  timeEntryView: 'table' | 'week' | 'stats';
   timeTableColumns: PopupColumnVisibility;
   timeTableColumnOrder: string[];
   timeTableSort: TimeTableSort;


### PR DESCRIPTION
## Summary

Adds a Statistics tab to the popup alongside Table and Week views. The new view reuses the weekly current-user worklog totals path to show total logged time, daily average, days logged, issues touched, daily totals, and top issues for the selected week.

## Details

- Adds persistent Table / Week / Stats tabs in the popup toolbar.
- Adds a shared top-right settings gear that is aligned consistently across all three views.
- Adds a compact-but-stable Stats popup layout so the view has enough room without the large empty tail.
- Updates the popup view storage type to support `stats`.
- Clears weekly/stat caches after logging time from the table so statistics refresh correctly.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `prettier --check src/html/popup.html src/ts/popup.ts src/ts/shared/types.ts`

Closes #38.