### PR TITLE
Improve settings page organization

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -4,77 +4,347 @@
     <meta charset="UTF-8" />
     <title>Jira Log Time Settings</title>
     <style>
-      /* Full viewport width so % widths in page view resolve against the window, not 750px. */
+      :root {
+        color-scheme: light;
+        --bg: #f7f8fa;
+        --surface: #ffffff;
+        --surface-alt: #f4f6f8;
+        --text: #172b4d;
+        --muted: #5e6c84;
+        --border: #dfe1e6;
+        --primary: #0052cc;
+        --primary-hover: #0041a8;
+        --success: #00875a;
+        --shadow: 0 10px 30px rgba(9, 30, 66, 0.08);
+      }
+
       html {
-        height: 100%;
+        min-height: 100%;
         width: 100%;
+        min-width: 750px;
+        overflow-y: scroll;
+        scrollbar-gutter: stable;
+        background: var(--bg);
       }
 
       body {
         width: 750px;
-        margin: 0 auto;
         min-height: 100vh;
+        margin: 0 auto;
         box-sizing: border-box;
+        padding: 0;
         font-family: Arial, sans-serif;
-        display: flex;
-        flex-direction: column;
-        background-color: #fff;
-        color: #000;
+        background: var(--bg);
+        color: var(--text);
       }
 
       html.page-view-layout body {
-        width: 100%;
-        max-width: 1400px;
-        padding: 0 clamp(12px, 4vw, 32px);
+        width: 750px;
+      }
+
+      a {
+        color: var(--primary);
+        text-decoration: none;
+      }
+
+      a:hover,
+      a:active,
+      a:focus {
+        text-decoration: underline;
       }
 
       .container {
-        flex: 1;
+        min-height: 100vh;
+        box-sizing: border-box;
+        padding: 16px 10px 82px;
+      }
+
+      .settings-shell {
+        display: grid;
+        gap: 14px;
+      }
+
+      .settings-header {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 116px;
+        align-items: flex-start;
+        gap: 16px;
+      }
+
+      .settings-title {
+        margin: 0;
+        font-size: 24px;
+        line-height: 1.2;
+        letter-spacing: 0;
+      }
+
+      .settings-subtitle {
+        margin: 5px 0 0;
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.4;
+      }
+
+      .page-actions {
         display: flex;
-        flex-direction: column;
-        padding: 10px;
-        padding-bottom: 60px; /* Space for sticky branding bar */
+        align-items: center;
+        justify-content: flex-end;
+        gap: 8px;
+        width: 116px;
       }
 
-      table {
-        width: 100%;
-        margin-bottom: 10px;
+      .settings-layout {
+        display: grid;
+        grid-template-columns: 52px minmax(0, 1fr);
+        gap: 12px;
+        align-items: start;
       }
 
-      td {
-        padding: 5px 0px 5px 0;
-        vertical-align: middle;
+      .settings-sidebar {
+        position: sticky;
+        top: 14px;
+        display: grid;
+        gap: 12px;
+        align-self: start;
       }
 
-      td:first-child {
-        width: 20%;
+      .settings-nav {
+        display: grid;
+        gap: 6px;
+        padding: 8px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        justify-items: center;
+      }
+
+      .settings-nav-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 34px;
+        height: 34px;
+        padding: 0;
+        border: 0;
+        border-radius: 6px;
+        background: transparent;
+        color: var(--muted);
+        cursor: pointer;
+        font: inherit;
+      }
+
+      .settings-nav-button:hover,
+      .settings-nav-button:focus-visible {
+        outline: none;
+        background: var(--surface-alt);
+        color: var(--text);
+      }
+
+      .settings-nav-button[aria-selected='true'] {
+        background: rgba(0, 82, 204, 0.1);
+        color: var(--primary);
+      }
+
+      .settings-nav-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+      }
+
+      .settings-nav-icon svg {
+        width: 18px;
+        height: 18px;
+        stroke: currentColor;
+      }
+
+      .settings-pages {
+        min-width: 0;
+      }
+
+      .settings-page {
+        display: none;
+      }
+
+      .settings-page.is-active {
+        display: block;
+      }
+
+      .settings-section {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        box-shadow: var(--shadow);
+        overflow: hidden;
+      }
+
+      .section-header {
+        padding: 14px 16px 10px;
+        border-bottom: 1px solid var(--border);
+        background: var(--surface-alt);
+      }
+
+      .section-title {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.3;
+      }
+
+      .section-note {
+        margin: 4px 0 0;
+        color: var(--muted);
+        font-size: 11px;
+        line-height: 1.4;
+      }
+
+      .settings-fields {
+        display: grid;
+      }
+
+      .setting-row {
+        display: grid;
+        grid-template-columns: minmax(150px, 0.34fr) minmax(0, 0.66fr);
+        gap: 14px;
+        padding: 13px 16px;
+        border-bottom: 1px solid var(--border);
+        align-items: center;
+      }
+
+      .setting-row:last-child {
+        border-bottom: 0;
+      }
+
+      .setting-label {
+        display: grid;
+        gap: 3px;
+        min-width: 0;
+      }
+
+      .setting-label label,
+      .setting-label span,
+      .field-label {
+        font-size: 12px;
+        font-weight: 700;
+        color: var(--text);
+        line-height: 1.35;
+      }
+
+      .setting-label small,
+      .field-help,
+      .toggle-label {
+        color: var(--muted);
+        font-size: 11px;
+        line-height: 1.4;
+      }
+
+      .required-marker {
+        color: var(--primary);
+      }
+
+      .setting-control {
+        display: grid;
+        gap: 6px;
+        min-width: 0;
       }
 
       input,
-      textarea {
+      textarea,
+      select {
         width: 100%;
         box-sizing: border-box;
+        border: 1px solid #c1c7d0;
+        border-radius: 6px;
+        background: #ffffff;
+        color: var(--text);
+        font: inherit;
+        font-size: 12px;
       }
 
-      #status {
-        height: 10px;
-        font-size: 11px;
-        font-weight: bold;
-        color: #666;
-        text-align: right;
-        margin-bottom: 5px;
+      input,
+      select {
+        min-height: 34px;
+        padding: 7px 9px;
       }
 
-      .btn {
-        width: 100%;
-        background: #0052cc;
+      textarea {
+        min-height: 74px;
+        padding: 8px 9px;
+        resize: vertical;
+      }
+
+      input:focus,
+      textarea:focus,
+      select:focus {
+        outline: none;
+        border-color: var(--primary);
+        box-shadow: 0 0 0 2px rgba(0, 82, 204, 0.16);
+      }
+
+      input:disabled {
+        background: var(--surface-alt);
+        color: var(--muted);
+      }
+
+      .text-setting-control {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 8px;
+        align-items: start;
+      }
+
+      .inline-save-button {
+        min-width: 64px;
+        min-height: 34px;
+        background: var(--primary);
         color: #fff;
-        border-radius: 8px;
+        border-radius: 6px;
         border: none;
-        padding: 10px;
-        font-size: 11px;
+        padding: 7px 12px;
+        font-size: 12px;
+        font-weight: 700;
         cursor: pointer;
-        margin-bottom: 10px;
+      }
+
+      .inline-save-button:hover {
+        background: var(--primary-hover);
+      }
+
+      .inline-save-button[hidden] {
+        display: none;
+      }
+
+      .field-icon-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 34px;
+        min-height: 34px;
+        box-sizing: border-box;
+        border: 1px solid #c1c7d0;
+        border-radius: 6px;
+        background: #ffffff;
+        color: var(--muted);
+        cursor: pointer;
+        padding: 0;
+      }
+
+      .field-icon-button:hover,
+      .field-icon-button:focus-visible {
+        outline: none;
+        border-color: var(--primary);
+        color: var(--primary);
+        box-shadow: 0 0 0 2px rgba(0, 82, 204, 0.16);
+      }
+
+      .field-icon-button svg {
+        width: 17px;
+        height: 17px;
+        stroke: currentColor;
+      }
+
+      .field-icon-button [hidden] {
+        display: none;
       }
 
       #brand {
@@ -105,11 +375,13 @@
         vertical-align: top;
         padding: 12px 5px 0 0;
       }
+
       #nav > * {
         display: inline-block;
         vertical-align: middle;
         margin: 0 3px;
       }
+
       #nav a img {
         display: block;
       }
@@ -119,61 +391,57 @@
         text-decoration: none;
       }
 
-      a {
-        color: #0052cc;
-        text-decoration: none;
-      }
-
-      a:hover,
-      a:active,
-      a:focus {
-        text-decoration: underline;
-      }
-
       .designed-by {
         font-size: 11px;
-        color: #666;
+        color: var(--muted);
         text-align: center;
-        margin: 6px 0 4px;
-      }
-      body.dark-mode .designed-by {
-        color: #e0e0e0;
+        margin: 4px 0 0;
       }
 
-      /* Ko-fi button, aligned with theme controls */
-      .kofi-btn {
+      .kofi-btn,
+      .report-btn {
         display: inline-flex;
         align-items: center;
+        justify-content: center;
         gap: 6px;
         padding: 0 8px;
         height: 24px;
         border-radius: 4px;
         background: rgba(0, 0, 0, 0.05);
-        color: #0052cc !important;
-        font-weight: 400;
+        color: var(--primary) !important;
+        font-weight: 500;
         text-decoration: none !important;
         line-height: 1;
         border: 1px solid transparent;
         vertical-align: middle;
       }
-      .kofi-btn:hover {
-        background-color: rgba(0, 0, 0, 0.12);
+
+      .report-btn {
+        width: 98px;
+        box-sizing: border-box;
+        white-space: nowrap;
       }
-      body.dark-mode .kofi-btn {
-        background: rgba(255, 255, 255, 0.1);
-        color: #4690dd !important;
+
+      .kofi-btn {
         font-weight: 400;
       }
-      body.dark-mode .kofi-btn:hover {
-        background-color: rgba(255, 255, 255, 0.18);
+
+      .kofi-btn:hover,
+      .report-btn:hover {
+        background-color: rgba(0, 0, 0, 0.12);
       }
-      .kofi-cup {
+
+      .kofi-cup,
+      .bug-icon {
         display: inline-block;
         will-change: transform;
       }
-      .kofi-btn:hover .kofi-cup {
+
+      .kofi-btn:hover .kofi-cup,
+      .report-btn:hover .bug-icon {
         animation: kofi-pop 0.4s ease-out;
       }
+
       @keyframes kofi-pop {
         0% {
           transform: translateY(0) scale(1);
@@ -186,90 +454,56 @@
         }
       }
 
-      /* Report bug button - small pill in top-right nav */
-      .report-btn {
-        display: inline-flex;
-        align-items: center;
-        gap: 6px;
-        padding: 0 8px;
-        height: 24px;
-        border-radius: 4px;
-        background: rgba(0, 0, 0, 0.05);
-        color: #0052cc !important; /* Extension blue */
-        font-weight: 500;
-        text-decoration: none !important;
-        line-height: 1;
-        border: 1px solid transparent;
-        vertical-align: middle;
-      }
-      .report-btn:hover {
-        background-color: rgba(0, 0, 0, 0.12);
-      }
-      .bug-icon {
-        display: inline-block;
-        will-change: transform;
-      }
-      .report-btn:hover .bug-icon {
-        animation: kofi-pop 0.4s ease-out;
-      }
-      body.dark-mode .report-btn {
-        background: rgba(255, 255, 255, 0.1);
-        color: #4690dd !important;
-      }
-      body.dark-mode .report-btn:hover {
-        background-color: rgba(255, 255, 255, 0.18);
-      }
-
-      /* Page-level top-right actions (outside table) */
-      .page-actions {
-        display: flex;
-        align-items: center;
-        justify-content: flex-end;
-        gap: 8px;
-        margin-bottom: 6px;
-      }
-
       .toggle-switch {
         position: relative;
         display: inline-block;
-        width: 60px;
-        height: 34px;
+        width: 54px;
+        height: 30px;
         vertical-align: middle;
-        overflow: visible; /* Allow shapes to extend beyond toggle bounds */
-        margin-right: 8px;
+        overflow: visible;
+      }
+
+      .toggle-control {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        min-width: 0;
+      }
+
+      .toggle-switch input,
+      .theme-toggle input {
+        display: none;
       }
 
       .slider {
         position: absolute;
         cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: #ccc;
-        transition: 0.4s;
-        border-radius: 34px;
+        inset: 0;
+        background-color: #c1c7d0;
+        transition: 0.25s;
+        border-radius: 30px;
       }
 
       .slider:before {
         position: absolute;
         content: '';
-        height: 26px;
-        width: 26px;
+        height: 22px;
+        width: 22px;
         left: 4px;
         bottom: 4px;
         background-color: white;
-        transition: 0.4s;
+        transition: 0.25s;
         border-radius: 50%;
-        z-index: 2; /* Ensure the circle is above the shapes */
+        z-index: 2;
+        box-shadow: 0 1px 3px rgba(9, 30, 66, 0.25);
       }
 
       input:checked + .slider {
-        background-color: #0052cc;
+        background-color: var(--primary);
       }
 
       input:checked + .slider:before {
-        transform: translateX(26px);
+        transform: translateX(24px);
       }
 
       .shape {
@@ -294,22 +528,91 @@
         }
       }
 
-      select {
-        width: 100%;
-        padding: 5px;
-        box-sizing: border-box;
+      .theme-button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 26px;
+        height: 24px;
+        border-radius: 4px;
+        cursor: pointer;
+        border: none;
+        vertical-align: middle;
+        transition: background-color 0.3s;
+        margin: 0 2px;
+        padding: 0;
+        font-size: 16px;
+        background: rgba(0, 0, 0, 0.05);
       }
 
-      /* ---------------- Dark Mode Styles ---------------- */
+      .theme-button:hover {
+        background-color: rgba(0, 0, 0, 0.15);
+      }
+
+      .theme-button .icon {
+        font-family:
+          'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+          'Noto Color Emoji';
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        line-height: 1;
+      }
+
+      .caret-button .icon {
+        font-family: Arial, Helvetica, sans-serif;
+        font-size: 18px;
+        transform: translateY(-1px);
+      }
+
+      .caret-button:hover,
+      .caret-button:focus,
+      .caret-button:focus-visible {
+        outline: none;
+        text-decoration: none;
+        background: #172b4d;
+        color: #ffffff;
+      }
+
+      .jira-popup-beta-badge {
+        display: inline-block;
+        background: #ff6b35;
+        color: white;
+        font-size: 10px;
+        font-weight: 700;
+        padding: 2px 6px;
+        border-radius: 8px;
+        vertical-align: middle;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        line-height: 1;
+        box-shadow: 0 1px 3px rgba(255, 107, 53, 0.3);
+      }
+
       body.dark-mode {
-        background-color: #141414;
-        color: #e0e0e0;
+        --bg: #141414;
+        --surface: #1a1a1a;
+        --surface-alt: #202020;
+        --text: #e0e0e0;
+        --muted: #b3bac5;
+        --border: #333333;
+        --primary: #4690dd;
+        --primary-hover: #5e9fe3;
+        --success: #79f2c0;
+        --shadow: none;
+        color-scheme: dark;
+      }
+
+      html.dark-mode {
+        background: #141414;
       }
 
       body.dark-mode input,
       body.dark-mode textarea,
       body.dark-mode select {
-        background-color: #1a1a1a;
+        background-color: #141414;
         color: #e0e0e0;
         border: 1px solid #333;
       }
@@ -317,18 +620,35 @@
       body.dark-mode input:focus,
       body.dark-mode textarea:focus,
       body.dark-mode select:focus {
-        outline: none;
         border-color: #4a90e2;
-        box-shadow: none;
+        box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
       }
 
-      body.dark-mode .btn {
+      body.dark-mode input:disabled {
+        background: #202020;
+        color: #b3bac5;
+      }
+
+      body.dark-mode .inline-save-button {
         background: #4690dd;
         color: #1a1a1a;
       }
 
-      body.dark-mode .btn:hover {
+      body.dark-mode .inline-save-button:hover {
         background: #5e9fe3;
+      }
+
+      body.dark-mode .field-icon-button {
+        background: #141414;
+        color: #b3bac5;
+        border-color: #333;
+      }
+
+      body.dark-mode .field-icon-button:hover,
+      body.dark-mode .field-icon-button:focus-visible {
+        border-color: #4a90e2;
+        color: #4690dd;
+        box-shadow: 0 0 0 2px rgba(74, 144, 226, 0.2);
       }
 
       body.dark-mode #brand {
@@ -338,10 +658,6 @@
 
       body.dark-mode a {
         color: #4690dd !important;
-      }
-
-      body.dark-mode #status {
-        color: #e0e0e0;
       }
 
       body.dark-mode .slider {
@@ -356,203 +672,24 @@
         background-color: #e0e0e0;
       }
 
-      body.dark-mode select {
-        background-color: #1a1a1a;
-        color: #e0e0e0;
-        border: 1px solid #333;
-      }
-
-      body.dark-mode select:focus {
-        border-color: #4a90e2;
-      }
-
-      body.dark-mode input[type='password'] {
-        background-color: #1a1a1a;
-        color: #e0e0e0;
-      }
-
-      body.dark-mode input[type='text'] {
-        background-color: #1a1a1a;
-        color: #e0e0e0;
-      }
-
-      body.dark-mode textarea {
-        background-color: #1a1a1a;
-        color: #e0e0e0;
-      }
-
-      /* Theme Toggle Styles */
-      .theme-toggle {
-        display: inline-flex;
-        align-items: center;
-        cursor: pointer;
-        margin: 0 4px;
-        vertical-align: middle;
-      }
-      .theme-toggle input {
-        display: none;
-      }
-      .theme-toggle-track {
-        width: 48px;
-        height: 24px;
-        background-color: #e2e8f0;
-        border-radius: 12px;
-        position: relative;
-        transition: background-color 0.3s;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 4px;
-      }
-      .theme-toggle input:checked + .theme-toggle-track {
-        background-color: #1a1a1a;
-      }
-      .theme-toggle-thumb {
-        position: absolute;
-        width: 20px;
-        height: 20px;
-        background-color: white;
-        border-radius: 50%;
-        top: 2px;
-        left: 2px;
-        transition: transform 0.3s;
-        z-index: 2;
-      }
-      .theme-toggle input:checked + .theme-toggle-track .theme-toggle-thumb {
-        transform: translateX(24px);
-        background-color: #1a1a1a;
-      }
-      .theme-toggle-icon {
-        font-size: 16px;
-        z-index: 1;
-        transition: opacity 0.3s;
-        height: 24px;
-        width: 20px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-family:
-          'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-          'Noto Color Emoji';
-        line-height: 1;
-        position: relative;
-        top: 0;
-      }
-      .theme-toggle-icon.sun {
-        opacity: 0;
-        padding-left: 2px;
-        font-size: 14px;
-      }
-      .theme-toggle-icon.moon {
-        opacity: 1;
-        padding-right: 2px;
-        font-size: 14px;
-      }
-      .theme-toggle input:checked + .theme-toggle-track .theme-toggle-icon.sun {
-        opacity: 1;
-      }
-      .theme-toggle
-        input:checked
-        + .theme-toggle-track
-        .theme-toggle-icon.moon {
-        opacity: 0;
-      }
-      body.dark-mode .theme-toggle-track {
-        background-color: #4a5568;
-      }
-      body.dark-mode .theme-toggle-thumb {
-        background-color: #1a1a1a;
-      }
-      /* Simple, minimal theme button with just the emoji - rounded square */
-      .theme-button {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 26px;
-        height: 24px;
-        border-radius: 4px; /* Rounded square */
-        cursor: pointer;
-        border: none;
-        vertical-align: middle;
-        transition: background-color 0.3s;
-        margin: 0 2px;
-        padding: 0;
-        font-size: 16px;
-        background: rgba(0, 0, 0, 0.05); /* Subtle background */
-      }
-      .theme-button:hover {
-        background-color: rgba(0, 0, 0, 0.15);
-      }
+      body.dark-mode .kofi-btn,
+      body.dark-mode .report-btn,
       body.dark-mode .theme-button {
         background: rgba(255, 255, 255, 0.1);
+        color: #4690dd !important;
       }
+
+      body.dark-mode .kofi-btn:hover,
+      body.dark-mode .report-btn:hover,
       body.dark-mode .theme-button:hover {
-        background-color: rgba(255, 255, 255, 0.2);
+        background-color: rgba(255, 255, 255, 0.18);
       }
-      /* Fun gradient focus/hover state for caret button */
-      .caret-button:hover,
-      .caret-button:focus,
-      .caret-button:focus-visible {
-        outline: none;
-        text-decoration: none;
-        background: linear-gradient(
-          135deg,
-          #4fd1ff 0%,
-          #7a5cff 50%,
-          #ff4fd1 100%
-        );
-        color: #ffffff;
-        box-shadow: 0 0 0 2px rgba(122, 92, 255, 0.35);
-      }
+
       body.dark-mode .caret-button:hover,
       body.dark-mode .caret-button:focus,
       body.dark-mode .caret-button:focus-visible {
-        outline: none;
-        background: linear-gradient(
-          135deg,
-          #4690dd 0%,
-          #7a5cff 50%,
-          #ff4fd1 100%
-        );
-        color: #1a1a1a;
-        box-shadow: 0 0 0 2px rgba(70, 144, 221, 0.35);
-      }
-      /* Emoji font support and perfect centering */
-      .theme-button .icon {
-        font-family:
-          'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-          'Noto Color Emoji';
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
-        line-height: 1;
-      }
-
-      /* Fine-tune caret button centering */
-      .caret-button .icon {
-        font-family: Arial, Helvetica, sans-serif;
-        font-size: 18px;
-        transform: translateY(-1px);
-      }
-
-      /* BETA badge for options - matching content-script style */
-      .jira-popup-beta-badge {
-        display: inline-block;
-        background: #ff6b35;
-        color: white;
-        font-size: 10px;
-        font-weight: 700;
-        padding: 2px 6px;
-        border-radius: 8px;
-        margin-left: 8px;
-        vertical-align: middle;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        line-height: 1;
-        box-shadow: 0 1px 3px rgba(255, 107, 53, 0.3);
-        animation: jiraBetaPulse 2s ease-in-out infinite;
+        background: #4690dd;
+        color: #1a1a1a !important;
       }
 
       body.dark-mode .jira-popup-beta-badge {
@@ -560,15 +697,26 @@
         box-shadow: 0 1px 3px rgba(255, 140, 66, 0.4);
       }
 
-      @keyframes jiraBetaPulse {
-        0%,
-        100% {
-          opacity: 1;
-          transform: scale(1);
+      body.dark-mode .settings-nav-button[aria-selected='true'] {
+        background: rgba(70, 144, 221, 0.16);
+      }
+
+      @media (max-width: 760px) {
+        .setting-row {
+          grid-template-columns: 1fr;
+          gap: 8px;
         }
-        50% {
-          opacity: 0.8;
-          transform: scale(1.05);
+
+        .text-setting-control {
+          grid-template-columns: 1fr;
+        }
+
+        #info {
+          width: 38%;
+        }
+
+        #nav {
+          width: 56%;
         }
       }
     </style>
@@ -576,175 +724,565 @@
 
   <body>
     <div class="container">
-      <div class="page-actions">
-        <a
-          href="https://github.com/haydencbarnes/jira-time-tracker-ext/issues/new?template=bug_report.md"
-          target="_blank"
-          tabindex="1"
-          class="report-btn"
-          title="Report a bug"
-          ><span class="bug-icon" aria-hidden="true">🐞</span
-          ><span class="report-text">Report bug</span></a
-        >
-      </div>
-      <table>
-        <tr>
-          <td colspan="2">
-            <span
-              ><b>*</b> = required to input/edit for extension access to
-              Jira</span
+      <main class="settings-shell">
+        <header class="settings-header">
+          <div>
+            <h1 class="settings-title">Settings</h1>
+            <p class="settings-subtitle">
+              Configure Jira access, saved worklog text, and extension behavior.
+            </p>
+          </div>
+          <div class="page-actions">
+            <a
+              href="https://github.com/haydencbarnes/jira-time-tracker-ext/issues/new?template=bug_report.md"
+              target="_blank"
+              tabindex="1"
+              class="report-btn"
+              title="Report a bug"
+              ><span class="bug-icon" aria-hidden="true">🐞</span
+              ><span class="report-text">Report bug</span></a
             >
-          </td>
-          <td><div id="status"></div></td>
-        </tr>
-        <tr>
-          <td><b>Jira Instance Type*</b></td>
-          <td>
-            <select id="jiraType">
-              <option value="cloud">Jira Cloud</option>
-              <option value="server">Jira Server</option>
-            </select>
-          </td>
-        </tr>
-        <tr id="urlRow">
-          <td><b>Jira URL*</b></td>
-          <td>
-            <input
-              id="baseUrl"
-              type="text"
-              placeholder="https://your-domain.atlassian.net"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td><b>Username/Email*</b></td>
-          <td>
-            <input
-              id="username"
-              type="text"
-              placeholder="your-email@example.com"
-            />
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <b
-              ><a
-                href="https://chatgpt.com/share/679db596-d5a0-8005-978c-00e438af637b"
-                target="_blank"
-                tabindex="1"
-                style="color: #0052cc"
-                >API Token*</a
-              ></b
-            >
-          </td>
-          <td>
-            <input id="password" type="password" placeholder="Your API Token" />
-          </td>
-        </tr>
-        <tr>
-          <td>Worklog Snippet (1)</td>
-          <td>
-            <textarea
-              id="frequentWorklogDescription1"
-              placeholder="Store and insert a frequently used worklog comment"
-            ></textarea>
-          </td>
-        </tr>
-        <tr>
-          <td>Worklog Snippet (2)</td>
-          <td>
-            <textarea
-              id="frequentWorklogDescription2"
-              placeholder="Store and insert a frequently used worklog comment"
-            ></textarea>
-          </td>
-        </tr>
-        <tr>
-          <td>Default Tab</td>
-          <td>
-            <select id="defaultPage">
-              <option value="popup.html">Time Table</option>
-              <option value="search.html">Search</option>
-              <option value="timerFeatureModule/timer.html">Timer</option>
-              <option value="cli.html">CLI</option>
-            </select>
-          </td>
-        </tr>
-        <tr id="darkModeRow">
-          <td>Follow System Color Scheme</td>
-          <td>
-            <div style="display: flex; align-items: center">
-              <label class="toggle-switch">
-                <input
-                  type="checkbox"
-                  id="systemThemeToggle"
-                  aria-label="Follow system color scheme"
-                />
-                <span class="slider"></span>
-              </label>
-            </div>
-          </td>
-        </tr>
-        <tr id="issueDetectionRow">
-          <td>Work Item ID Detection</td>
-          <td>
-            <label class="toggle-switch">
-              <input type="checkbox" id="issueDetectionToggle" />
-              <span class="slider"></span>
-            </label>
-          </td>
-        </tr>
-        <tr>
-          <td>Experimental Features</td>
-          <td>
-            <label class="toggle-switch">
-              <input type="checkbox" id="experimentalFeatures" />
-              <span class="slider"></span>
-            </label>
-            <span class="toggle-label"
-              >(Calendar Add-on, page view in a new tab, Floating Timer Widget
-              + More Coming Soon!)</span
-            >
-          </td>
-        </tr>
-        <tr id="pageViewRow" style="display: none">
-          <td>Page view (new tab)</td>
-          <td>
-            <label class="toggle-switch">
-              <input type="checkbox" id="pageViewToggle" />
-              <span class="slider"></span>
-            </label>
-            <span class="jira-popup-beta-badge">Beta</span>
-          </td>
-        </tr>
-        <tr id="floatingTimerWidgetRow" style="display: none">
-          <td>Floating Timer Widget</td>
-          <td>
-            <label class="toggle-switch">
-              <input type="checkbox" id="floatingTimerWidgetToggle" />
-              <span class="slider"></span>
-            </label>
-            <span class="jira-popup-beta-badge">Beta</span>
-            <span class="toggle-label"
-              >(Shows a bottom-right timer on web pages)</span
-            >
-          </td>
-        </tr>
-        <tr>
-          <td>Version</td>
-          <td>
-            <input id="version" type="text" value="" disabled />
-          </td>
-        </tr>
-      </table>
+          </div>
+        </header>
 
-      <button id="save" class="btn">Save</button>
+        <div class="settings-layout">
+          <aside class="settings-sidebar" aria-label="Settings sections">
+            <nav
+              class="settings-nav"
+              role="tablist"
+              aria-label="Settings pages"
+            >
+              <button
+                id="accountTab"
+                type="button"
+                class="settings-nav-button"
+                data-settings-page-target="account"
+                role="tab"
+                aria-selected="true"
+                aria-controls="accountPage"
+                aria-label="Account"
+                title="Account"
+              >
+                <span class="settings-nav-icon" aria-hidden="true">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M20 21a8 8 0 0 0-16 0" />
+                    <circle cx="12" cy="7" r="4" />
+                  </svg>
+                </span>
+              </button>
+              <button
+                id="worklogsTab"
+                type="button"
+                class="settings-nav-button"
+                data-settings-page-target="worklogs"
+                role="tab"
+                aria-selected="false"
+                aria-controls="worklogsPage"
+                aria-label="Worklogs"
+                title="Worklogs"
+              >
+                <span class="settings-nav-icon" aria-hidden="true">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M8 6h13" />
+                    <path d="M8 12h13" />
+                    <path d="M8 18h13" />
+                    <path d="M3 6h.01" />
+                    <path d="M3 12h.01" />
+                    <path d="M3 18h.01" />
+                  </svg>
+                </span>
+              </button>
+              <button
+                id="behaviorTab"
+                type="button"
+                class="settings-nav-button"
+                data-settings-page-target="behavior"
+                role="tab"
+                aria-selected="false"
+                aria-controls="behaviorPage"
+                aria-label="Behavior"
+                title="Behavior"
+              >
+                <span class="settings-nav-icon" aria-hidden="true">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M4 21v-7" />
+                    <path d="M4 10V3" />
+                    <path d="M12 21v-9" />
+                    <path d="M12 8V3" />
+                    <path d="M20 21v-5" />
+                    <path d="M20 12V3" />
+                    <path d="M2 14h4" />
+                    <path d="M10 8h4" />
+                    <path d="M18 16h4" />
+                  </svg>
+                </span>
+              </button>
+              <button
+                id="experimentalTab"
+                type="button"
+                class="settings-nav-button"
+                data-settings-page-target="experimental"
+                role="tab"
+                aria-selected="false"
+                aria-controls="experimentalPage"
+                aria-label="Experimental"
+                title="Experimental"
+              >
+                <span class="settings-nav-icon" aria-hidden="true">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M9 3h6" />
+                    <path
+                      d="M10 3v6l-4 8a3 3 0 0 0 2.7 4.3h6.6A3 3 0 0 0 18 17l-4-8V3"
+                    />
+                    <path d="M8 14h8" />
+                  </svg>
+                </span>
+              </button>
+              <button
+                id="aboutTab"
+                type="button"
+                class="settings-nav-button"
+                data-settings-page-target="about"
+                role="tab"
+                aria-selected="false"
+                aria-controls="aboutPage"
+                aria-label="About"
+                title="About"
+              >
+                <span class="settings-nav-icon" aria-hidden="true">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <circle cx="12" cy="12" r="10" />
+                    <path d="M12 16v-4" />
+                    <path d="M12 8h.01" />
+                  </svg>
+                </span>
+              </button>
+            </nav>
+          </aside>
 
-      <div class="designed-by">
-        Designed by Hayden Barnes in Kansas City, Kansas
-        <span style="color: #0052cc">&#10084;</span>
-      </div>
+          <div class="settings-pages">
+            <section
+              class="settings-page is-active"
+              id="accountPage"
+              data-settings-page="account"
+              role="tabpanel"
+              aria-labelledby="accountTab"
+            >
+              <div class="settings-section">
+                <div class="section-header">
+                  <h2 class="section-title">Account</h2>
+                  <p class="section-note">
+                    Required fields are marked with
+                    <span class="required-marker">*</span>.
+                  </p>
+                </div>
+                <div class="settings-fields">
+                  <div class="setting-row">
+                    <div class="setting-label">
+                      <label for="jiraType"
+                        >Jira instance
+                        <span class="required-marker">*</span></label
+                      >
+                    </div>
+                    <div class="setting-control">
+                      <select id="jiraType">
+                        <option value="cloud">Jira Cloud</option>
+                        <option value="server">Jira Server</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div class="setting-row" id="urlRow">
+                    <div class="setting-label">
+                      <label for="baseUrl"
+                        ><span id="urlLabel">Jira URL</span>
+                        <span class="required-marker">*</span></label
+                      >
+                    </div>
+                    <div class="setting-control">
+                      <div class="text-setting-control">
+                        <input
+                          id="baseUrl"
+                          type="text"
+                          placeholder="https://your-domain.atlassian.net"
+                        />
+                        <button
+                          type="button"
+                          class="inline-save-button"
+                          data-save-input="baseUrl"
+                          hidden
+                        >
+                          Save
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="setting-row">
+                    <div class="setting-label">
+                      <label for="username"
+                        >Username or email
+                        <span class="required-marker">*</span></label
+                      >
+                    </div>
+                    <div class="setting-control">
+                      <div class="text-setting-control">
+                        <input
+                          id="username"
+                          type="password"
+                          placeholder="your-email@example.com"
+                        />
+                        <button
+                          id="usernameVisibilityToggle"
+                          type="button"
+                          class="field-icon-button"
+                          aria-label="Show email"
+                          title="Show email"
+                        >
+                          <span class="visibility-icon-show" aria-hidden="true">
+                            <svg
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                            >
+                              <path d="M2.06 12.35a11.1 11.1 0 0 1 19.88 0" />
+                              <path d="M21.94 11.65a11.1 11.1 0 0 1-19.88 0" />
+                              <circle cx="12" cy="12" r="3" />
+                            </svg>
+                          </span>
+                          <span
+                            class="visibility-icon-hide"
+                            aria-hidden="true"
+                            hidden
+                          >
+                            <svg
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                            >
+                              <path d="M17.94 17.94A10.9 10.9 0 0 1 12 20" />
+                              <path
+                                d="M6.06 6.06A10.9 10.9 0 0 0 2 12a11.1 11.1 0 0 0 5.14 5.64"
+                              />
+                              <path
+                                d="M9.9 4.24A10.9 10.9 0 0 1 12 4a11.1 11.1 0 0 1 10 8 10.8 10.8 0 0 1-2.29 3.95"
+                              />
+                              <path d="M14.12 14.12a3 3 0 0 1-4.24-4.24" />
+                              <path d="M3 3l18 18" />
+                            </svg>
+                          </span>
+                        </button>
+                        <button
+                          type="button"
+                          class="inline-save-button"
+                          data-save-input="username"
+                          hidden
+                        >
+                          Save
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="setting-row">
+                    <div class="setting-label">
+                      <a
+                        class="field-label"
+                        href="https://chatgpt.com/share/679db596-d5a0-8005-978c-00e438af637b"
+                        target="_blank"
+                        tabindex="1"
+                        >API token <span class="required-marker">*</span></a
+                      >
+                    </div>
+                    <div class="setting-control">
+                      <div class="text-setting-control">
+                        <input
+                          id="password"
+                          type="password"
+                          placeholder="Your API token"
+                        />
+                        <button
+                          type="button"
+                          class="inline-save-button"
+                          data-save-input="password"
+                          hidden
+                        >
+                          Save
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section
+              class="settings-page"
+              id="worklogsPage"
+              data-settings-page="worklogs"
+              role="tabpanel"
+              aria-labelledby="worklogsTab"
+              hidden
+            >
+              <div class="settings-section">
+                <div class="section-header">
+                  <h2 class="section-title">Worklog snippets</h2>
+                  <p class="section-note">
+                    Saved text appears as quick insert buttons when logging
+                    time.
+                  </p>
+                </div>
+                <div class="settings-fields">
+                  <div class="setting-row">
+                    <div class="setting-label">
+                      <label for="frequentWorklogDescription1">Snippet 1</label>
+                    </div>
+                    <div class="setting-control">
+                      <div class="text-setting-control">
+                        <textarea
+                          id="frequentWorklogDescription1"
+                          placeholder="Store and insert a frequently used worklog comment"
+                        ></textarea>
+                        <button
+                          type="button"
+                          class="inline-save-button"
+                          data-save-input="frequentWorklogDescription1"
+                          hidden
+                        >
+                          Save
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="setting-row">
+                    <div class="setting-label">
+                      <label for="frequentWorklogDescription2">Snippet 2</label>
+                    </div>
+                    <div class="setting-control">
+                      <div class="text-setting-control">
+                        <textarea
+                          id="frequentWorklogDescription2"
+                          placeholder="Store and insert a frequently used worklog comment"
+                        ></textarea>
+                        <button
+                          type="button"
+                          class="inline-save-button"
+                          data-save-input="frequentWorklogDescription2"
+                          hidden
+                        >
+                          Save
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section
+              class="settings-page"
+              id="behaviorPage"
+              data-settings-page="behavior"
+              role="tabpanel"
+              aria-labelledby="behaviorTab"
+              hidden
+            >
+              <div class="settings-section">
+                <div class="section-header">
+                  <h2 class="section-title">Behavior</h2>
+                  <p class="section-note">
+                    Choose the default destination and everyday extension
+                    behavior.
+                  </p>
+                </div>
+                <div class="settings-fields">
+                  <div class="setting-row">
+                    <div class="setting-label">
+                      <label for="defaultPage">Default tab</label>
+                    </div>
+                    <div class="setting-control">
+                      <select id="defaultPage">
+                        <option value="popup.html">Time Table</option>
+                        <option value="search.html">Search</option>
+                        <option value="timerFeatureModule/timer.html">
+                          Timer
+                        </option>
+                        <option value="cli.html">CLI</option>
+                      </select>
+                    </div>
+                  </div>
+                  <div class="setting-row" id="darkModeRow">
+                    <div class="setting-label">
+                      <span>Follow system color scheme</span>
+                    </div>
+                    <div class="setting-control">
+                      <div class="toggle-control">
+                        <label class="toggle-switch">
+                          <input
+                            type="checkbox"
+                            id="systemThemeToggle"
+                            aria-label="Follow system color scheme"
+                          />
+                          <span class="slider"></span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="setting-row" id="issueDetectionRow">
+                    <div class="setting-label">
+                      <span>Work item ID detection</span>
+                    </div>
+                    <div class="setting-control">
+                      <div class="toggle-control">
+                        <label class="toggle-switch">
+                          <input type="checkbox" id="issueDetectionToggle" />
+                          <span class="slider"></span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section
+              class="settings-page"
+              id="experimentalPage"
+              data-settings-page="experimental"
+              role="tabpanel"
+              aria-labelledby="experimentalTab"
+              hidden
+            >
+              <div class="settings-section">
+                <div class="section-header">
+                  <h2 class="section-title">Experimental</h2>
+                  <p class="section-note">
+                    Early features stay grouped here while they settle in.
+                  </p>
+                </div>
+                <div class="settings-fields">
+                  <div class="setting-row">
+                    <div class="setting-label">
+                      <span>Experimental features</span>
+                      <small>Calendar add-on, page view, floating timer</small>
+                    </div>
+                    <div class="setting-control">
+                      <div class="toggle-control">
+                        <label class="toggle-switch">
+                          <input type="checkbox" id="experimentalFeatures" />
+                          <span class="slider"></span>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="setting-row"
+                    id="pageViewRow"
+                    style="display: none"
+                  >
+                    <div class="setting-label">
+                      <span>Page view</span>
+                      <small>Open from the toolbar in a new tab</small>
+                    </div>
+                    <div class="setting-control">
+                      <div class="toggle-control">
+                        <label class="toggle-switch">
+                          <input type="checkbox" id="pageViewToggle" />
+                          <span class="slider"></span>
+                        </label>
+                        <span class="jira-popup-beta-badge">Beta</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div
+                    class="setting-row"
+                    id="floatingTimerWidgetRow"
+                    style="display: none"
+                  >
+                    <div class="setting-label">
+                      <span>Floating timer widget</span>
+                      <small>Shows a bottom-right timer on web pages</small>
+                    </div>
+                    <div class="setting-control">
+                      <div class="toggle-control">
+                        <label class="toggle-switch">
+                          <input
+                            type="checkbox"
+                            id="floatingTimerWidgetToggle"
+                          />
+                          <span class="slider"></span>
+                        </label>
+                        <span class="jira-popup-beta-badge">Beta</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <section
+              class="settings-page"
+              id="aboutPage"
+              data-settings-page="about"
+              role="tabpanel"
+              aria-labelledby="aboutTab"
+              hidden
+            >
+              <div class="settings-section">
+                <div class="section-header">
+                  <h2 class="section-title">About</h2>
+                </div>
+                <div class="settings-fields">
+                  <div class="setting-row">
+                    <div class="setting-label">
+                      <label for="version">Version</label>
+                    </div>
+                    <div class="setting-control">
+                      <input id="version" type="text" value="" disabled />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+
+        <div class="designed-by">
+          Designed by Hayden Barnes in Kansas City, Kansas
+          <span style="color: #0052cc">&#10084;</span>
+        </div>
+      </main>
     </div>
     <div id="brand">
       <div id="info">

--- a/src/ts/options.ts
+++ b/src/ts/options.ts
@@ -30,8 +30,21 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
   });
 }
 
+type TextSettingStorageKey =
+  | 'apiToken'
+  | 'baseUrl'
+  | 'frequentWorklogDescription1'
+  | 'frequentWorklogDescription2'
+  | 'username';
+
+interface TextSettingControl {
+  input: HTMLInputElement | HTMLTextAreaElement;
+  saveButton: HTMLButtonElement;
+  savedValue: string;
+  storageKey: TextSettingStorageKey;
+}
+
 (function initOptionsPage() {
-  const saveButton = getRequiredElement<HTMLButtonElement>('save');
   const versionInput = getRequiredElement<HTMLInputElement>('version');
   const experimentalFeaturesToggle = getRequiredElement<HTMLInputElement>(
     'experimentalFeatures'
@@ -43,20 +56,22 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
     '#experimentalFeatures + .slider'
   );
   const jiraTypeSelect = getRequiredElement<HTMLSelectElement>('jiraType');
-  const urlRow = getRequiredElement<HTMLTableRowElement>('urlRow');
+  const urlLabel = getRequiredElement<HTMLElement>('urlLabel');
   const baseUrlInput = getRequiredElement<HTMLInputElement>('baseUrl');
   const systemThemeToggle =
     getRequiredElement<HTMLInputElement>('systemThemeToggle');
-  const pageViewToggle =
-    getRequiredElement<HTMLInputElement>('pageViewToggle');
-  const pageViewRow = getRequiredElement<HTMLTableRowElement>('pageViewRow');
+  const pageViewToggle = getRequiredElement<HTMLInputElement>('pageViewToggle');
+  const pageViewRow = getRequiredElement<HTMLElement>('pageViewRow');
   const floatingTimerWidgetToggle = getRequiredElement<HTMLInputElement>(
     'floatingTimerWidgetToggle'
   );
-  const floatingTimerWidgetRow = getRequiredElement<HTMLTableRowElement>(
+  const floatingTimerWidgetRow = getRequiredElement<HTMLElement>(
     'floatingTimerWidgetRow'
   );
   const usernameInput = getRequiredElement<HTMLInputElement>('username');
+  const usernameVisibilityToggle = getRequiredElement<HTMLButtonElement>(
+    'usernameVisibilityToggle'
+  );
   const passwordInput = getRequiredElement<HTMLInputElement>('password');
   const frequentWorklogDescription1Input = getRequiredElement<HTMLInputElement>(
     'frequentWorklogDescription1'
@@ -66,22 +81,65 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
   );
   const defaultPageSelect =
     getRequiredElement<HTMLSelectElement>('defaultPage');
-  const statusElement = getRequiredElement<HTMLDivElement>('status');
+  const settingsNavButtons = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[data-settings-page-target]')
+  );
+  const settingsPages = Array.from(
+    document.querySelectorAll<HTMLElement>('[data-settings-page]')
+  );
+  const textSettingControls: TextSettingControl[] = [
+    {
+      input: baseUrlInput,
+      saveButton: getRequiredSelector<HTMLButtonElement>(
+        '[data-save-input="baseUrl"]'
+      ),
+      savedValue: '',
+      storageKey: 'baseUrl',
+    },
+    {
+      input: usernameInput,
+      saveButton: getRequiredSelector<HTMLButtonElement>(
+        '[data-save-input="username"]'
+      ),
+      savedValue: '',
+      storageKey: 'username',
+    },
+    {
+      input: passwordInput,
+      saveButton: getRequiredSelector<HTMLButtonElement>(
+        '[data-save-input="password"]'
+      ),
+      savedValue: '',
+      storageKey: 'apiToken',
+    },
+    {
+      input: frequentWorklogDescription1Input,
+      saveButton: getRequiredSelector<HTMLButtonElement>(
+        '[data-save-input="frequentWorklogDescription1"]'
+      ),
+      savedValue: '',
+      storageKey: 'frequentWorklogDescription1',
+    },
+    {
+      input: frequentWorklogDescription2Input,
+      saveButton: getRequiredSelector<HTMLButtonElement>(
+        '[data-save-input="frequentWorklogDescription2"]'
+      ),
+      savedValue: '',
+      storageKey: 'frequentWorklogDescription2',
+    },
+  ];
 
   document.addEventListener('DOMContentLoaded', restoreOptions);
   document.addEventListener('DOMContentLoaded', () => {
     versionInput.value = chrome.runtime.getManifest().version;
   });
-  saveButton.addEventListener('click', saveOptions);
 
   initThemeControls();
+  initSettingsNavigation();
+  initEmailVisibilityToggle();
+  initAutosaveControls();
   createExperimentalShapes();
-
-  experimentalFeaturesToggle.addEventListener(
-    'change',
-    onExperimentalToggleChange
-  );
-  jiraTypeSelect.addEventListener('change', onJiraTypeChange);
 
   function createExperimentalShapes(): void {
     const shapeCount = 15;
@@ -117,6 +175,122 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
     });
   }
 
+  function initSettingsNavigation(): void {
+    showSettingsPage(settingsNavButtons[0]?.dataset.settingsPageTarget ?? '');
+
+    settingsNavButtons.forEach((button, index) => {
+      button.addEventListener('click', () => {
+        showSettingsPage(button.dataset.settingsPageTarget ?? '');
+      });
+
+      button.addEventListener('keydown', (event) => {
+        if (
+          !['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight'].includes(
+            event.key
+          )
+        ) {
+          return;
+        }
+
+        event.preventDefault();
+        const direction =
+          event.key === 'ArrowDown' || event.key === 'ArrowRight' ? 1 : -1;
+        const nextIndex =
+          (index + direction + settingsNavButtons.length) %
+          settingsNavButtons.length;
+        const nextButton = settingsNavButtons[nextIndex];
+        nextButton.focus();
+        showSettingsPage(nextButton.dataset.settingsPageTarget ?? '');
+      });
+    });
+  }
+
+  function initEmailVisibilityToggle(): void {
+    usernameVisibilityToggle.addEventListener('click', () => {
+      const isVisible = usernameInput.type === 'text';
+      usernameInput.type = isVisible ? 'password' : 'text';
+      usernameVisibilityToggle.setAttribute(
+        'aria-label',
+        isVisible ? 'Show email' : 'Hide email'
+      );
+      usernameVisibilityToggle.title = isVisible ? 'Show email' : 'Hide email';
+      usernameVisibilityToggle
+        .querySelector<HTMLElement>('.visibility-icon-show')
+        ?.toggleAttribute('hidden', !isVisible);
+      usernameVisibilityToggle
+        .querySelector<HTMLElement>('.visibility-icon-hide')
+        ?.toggleAttribute('hidden', isVisible);
+    });
+  }
+
+  function showSettingsPage(pageName: string): void {
+    settingsNavButtons.forEach((button) => {
+      const isSelected = button.dataset.settingsPageTarget === pageName;
+      button.setAttribute('aria-selected', String(isSelected));
+      button.tabIndex = isSelected ? 0 : -1;
+    });
+
+    settingsPages.forEach((page) => {
+      const isSelected = page.dataset.settingsPage === pageName;
+      page.classList.toggle('is-active', isSelected);
+      page.hidden = !isSelected;
+    });
+  }
+
+  function initAutosaveControls(): void {
+    textSettingControls.forEach((control) => {
+      control.input.addEventListener('input', () => {
+        updateInlineSaveButton(control);
+      });
+
+      control.saveButton.addEventListener('click', () => {
+        void saveTextSetting(control);
+      });
+    });
+
+    jiraTypeSelect.addEventListener('change', () => {
+      onJiraTypeChange();
+      void setSyncStorage({
+        jiraType: jiraTypeSelect.value as JiraType,
+      });
+    });
+
+    defaultPageSelect.addEventListener('change', () => {
+      void setSyncStorage({
+        defaultPage: defaultPageSelect.value,
+      });
+    });
+
+    issueDetectionToggle.addEventListener('change', () => {
+      void saveFeatureSettings();
+    });
+
+    experimentalFeaturesToggle.addEventListener(
+      'change',
+      onExperimentalToggleChange
+    );
+    pageViewToggle.addEventListener('change', () => {
+      void saveFeatureSettings();
+    });
+    floatingTimerWidgetToggle.addEventListener('change', () => {
+      void saveFeatureSettings();
+    });
+  }
+
+  function updateInlineSaveButton(control: TextSettingControl): void {
+    control.saveButton.hidden = control.input.value === control.savedValue;
+  }
+
+  async function saveTextSetting(control: TextSettingControl): Promise<void> {
+    control.saveButton.disabled = true;
+    await setSyncStorage({
+      [control.storageKey]: control.input.value,
+    });
+    control.savedValue = control.input.value;
+    control.saveButton.disabled = false;
+    updateInlineSaveButton(control);
+  }
+
   function onExperimentalToggleChange(): void {
     const isEnabled = experimentalFeaturesToggle.checked;
     experimentalSlider
@@ -124,32 +298,37 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
       .forEach((shape) => {
         shape.style.opacity = isEnabled ? '1' : '0';
       });
-    pageViewRow.style.display = isEnabled ? 'table-row' : 'none';
-    floatingTimerWidgetRow.style.display = isEnabled ? 'table-row' : 'none';
+    setExperimentalRowsVisible(isEnabled);
 
     if (!isEnabled) {
       pageViewToggle.checked = false;
       floatingTimerWidgetToggle.checked = false;
-      chrome.storage.sync.set({
-        pageViewNewTabEnabled: false,
-        floatingTimerWidgetEnabled: false,
-      });
     }
+
+    void saveFeatureSettings();
   }
 
   function onJiraTypeChange(): void {
-    const urlLabel = urlRow.querySelector<HTMLElement>('td:first-child b');
     if (jiraTypeSelect.value === 'server') {
       baseUrlInput.placeholder = 'https://your-jira-server.com';
-      if (urlLabel) {
-        urlLabel.textContent = 'Jira Server URL*';
-      }
+      urlLabel.textContent = 'Jira Server URL';
     } else {
       baseUrlInput.placeholder = 'https://your-domain.atlassian.net';
-      if (urlLabel) {
-        urlLabel.textContent = 'Jira Cloud URL*';
-      }
+      urlLabel.textContent = 'Jira Cloud URL';
     }
+  }
+
+  function setExperimentalRowsVisible(isVisible: boolean): void {
+    const display = isVisible ? '' : 'none';
+    pageViewRow.style.display = display;
+    floatingTimerWidgetRow.style.display = display;
+  }
+
+  function markTextSettingsSaved(): void {
+    textSettingControls.forEach((control) => {
+      control.savedValue = control.input.value;
+      updateInlineSaveButton(control);
+    });
   }
 
   async function notifyTabs(message: SettingsChangedMessage): Promise<void> {
@@ -167,23 +346,17 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
     });
   }
 
-  async function saveOptions(): Promise<void> {
+  async function saveFeatureSettings(): Promise<void> {
     const experimentalFeatures = experimentalFeaturesToggle.checked;
     const issueDetectionEnabled = issueDetectionToggle.checked;
-    const pageViewNewTabEnabled = experimentalFeatures && pageViewToggle.checked;
+    const pageViewNewTabEnabled =
+      experimentalFeatures && pageViewToggle.checked;
     const floatingTimerWidgetEnabled =
       experimentalFeatures && floatingTimerWidgetToggle.checked;
 
     await setSyncStorage({
-      jiraType: jiraTypeSelect.value as JiraType,
-      username: usernameInput.value,
-      apiToken: passwordInput.value,
-      baseUrl: baseUrlInput.value,
       experimentalFeatures,
       issueDetectionEnabled,
-      frequentWorklogDescription1: frequentWorklogDescription1Input.value,
-      frequentWorklogDescription2: frequentWorklogDescription2Input.value,
-      defaultPage: defaultPageSelect.value,
       pageViewNewTabEnabled,
       floatingTimerWidgetEnabled,
     });
@@ -194,11 +367,6 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
       issueDetectionEnabled,
       floatingTimerWidgetEnabled,
     });
-
-    statusElement.textContent = 'Options saved.';
-    window.setTimeout(() => {
-      statusElement.textContent = '';
-    }, 1000);
   }
 
   async function restoreOptions(): Promise<void> {
@@ -228,19 +396,15 @@ function setSyncStorage(items: Record<string, unknown>): Promise<void> {
     frequentWorklogDescription2Input.value = items.frequentWorklogDescription2;
     defaultPageSelect.value = items.defaultPage;
     systemThemeToggle.checked = items.followSystemTheme;
-    pageViewRow.style.display = items.experimentalFeatures
-      ? 'table-row'
-      : 'none';
+    setExperimentalRowsVisible(items.experimentalFeatures ?? false);
     pageViewToggle.checked = !!(
       items.experimentalFeatures && items.pageViewNewTabEnabled
     );
-    floatingTimerWidgetRow.style.display = items.experimentalFeatures
-      ? 'table-row'
-      : 'none';
     floatingTimerWidgetToggle.checked = !!(
       items.experimentalFeatures && items.floatingTimerWidgetEnabled
     );
-    jiraTypeSelect.dispatchEvent(new Event('change'));
+    markTextSettingsSaved();
+    onJiraTypeChange();
   }
 })();
 


### PR DESCRIPTION
## Summary

Closes #44.

This updates the extension settings page into a page-style layout with an icon-only left rail, organized settings sections, and a stable header action area. It also removes the global save button in favor of immediate saves for select/toggle settings and per-field inline save buttons while typing.

The account page now masks the username/email by default and includes a small visibility toggle so users can show or hide their email without changing the saved value.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npx prettier --check src/html/options.html src/ts/options.ts`
- `npm run build`
- Browser-verified the options page layout, report bug button stability, email show/hide behavior, and inline email save behavior.
