### PR TITLE
Fix time view default persistence

### DIFF
--- a/src/ts/popup.ts
+++ b/src/ts/popup.ts
@@ -507,10 +507,6 @@ function initViewControls() {
       if (!isTimeEntryView(view)) return;
 
       setTimeEntryView(view);
-      if (currentPopupOptions) {
-        currentPopupOptions.timeEntryView = view;
-      }
-      chrome.storage.sync.set({ timeEntryView: view });
     });
   });
 
@@ -875,7 +871,7 @@ function syncGearPanelState(options: PopupOptions) {
   const viewSelect = document.getElementById(
     'gear-time-entry-view-select'
   ) as HTMLSelectElement | null;
-  if (viewSelect) viewSelect.value = activeTimeEntryView;
+  if (viewSelect) viewSelect.value = options.timeEntryView;
 
   renderGearColumnOrder(
     options.timeTableColumnOrder.filter(isColumnId),


### PR DESCRIPTION
## Summary

Fixes the time tab view selector so choosing Table, Week, or Stats only changes the current popup view and does not overwrite the saved default view setting.

## Root cause

The toolbar view buttons were writing each clicked view back to `chrome.storage.sync.timeEntryView` and mutating `currentPopupOptions.timeEntryView`. The gear settings panel also populated the Default view select from the transient active view, so opening settings after switching tabs made the clicked tab appear as the saved default.

## Impact

Users can temporarily switch time views without changing their configured default. The Default view setting is now only updated when saved from the gear settings panel.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run build`